### PR TITLE
Update Code Engine skills with release safeguards and version verification

### DIFF
--- a/skills/cli/code-engine-create/SKILL.md
+++ b/skills/cli/code-engine-create/SKILL.md
@@ -32,6 +32,14 @@ Fallback endpoint when CLI path is unavailable:
 POST /api/codeengine/v2/packages
 ```
 
+## Release Safety Rule
+
+Hard rule: never call any Code Engine release endpoint unless the user explicitly says **"release"**.
+
+- Do not infer release from context.
+- Do not release as part of "finish", "publish", or "make it work".
+- If release appears necessary, stop and ask for explicit release approval first.
+
 ## Required Payload Shape
 
 ```json
@@ -59,6 +67,11 @@ POST /api/codeengine/v2/packages
 }
 ```
 
+Create semantics:
+
+- `POST /api/codeengine/v2/packages` creates a package or version payload target.
+- For a new version on an existing package, include `id` and `version` in the create body and send full code/manifest payload.
+
 ## Datatype Mapping Rules (Auto-Map)
 
 When generating `manifest.functions[].inputs/parameters/output`, apply these defaults:
@@ -82,11 +95,27 @@ After successful create, update app `manifest.json` `packagesMapping`:
 
 If package ID/version changes, treat existing mapping as drift and sync immediately unless user requests otherwise.
 
+## Post-Create Verification (Required)
+
+After create, verify target package/version before declaring success:
+
+1. `GET /api/codeengine/v2/packages/{packageId}`
+2. Confirm target version exists and includes expected function names.
+3. Confirm function inputs/outputs have expected datatypes and nullability.
+
+If create returns an incomplete version shell (for example missing function contracts), hand off to update flow:
+
+- `PUT /api/codeengine/v2/packages/{id}/versions/{version}` via `code-engine-update`
+- Re-run verification after update
+
 ## Checklist
 
 - [ ] CLI-first create attempted
 - [ ] Endpoint fallback documented if CLI unavailable
 - [ ] Payload contains `manifest.functions`
 - [ ] Datatype mapping applied to each function input/output
+- [ ] Release was **not** called unless user explicitly requested release
+- [ ] Post-create verification completed on target package/version
+- [ ] Incomplete create result routed to `code-engine-update` and re-verified
 - [ ] `packagesMapping` updated in manifest after create
 - [ ] Result includes package id/version for downstream steps

--- a/skills/cli/code-engine-update/SKILL.md
+++ b/skills/cli/code-engine-update/SKILL.md
@@ -34,13 +34,27 @@ POST /api/codeengine/v2/packages
 
 with `id` and `version` set in body for versioned update behavior.
 
+## Release Safety Rule
+
+Hard rule: never call any Code Engine release endpoint unless the user explicitly says **\"release\"**.
+
+- Do not infer release from context.
+- Do not release as part of \"finish\", \"publish\", or \"make it work\".
+- If release appears necessary, stop and ask for explicit release approval first.
+
 ## Update/New-Version Behavior
 
-Use this decision model:
+Preferred create/update model:
 
-- no `packageId` -> create flow (handoff to `code-engine-create`)
-- `packageId` only -> update current package context
-- `packageId` + `version` -> create/update that explicit version
+1. Create a new package: `POST /api/codeengine/v2/packages`
+2. Create a new version of an existing package: also `POST /api/codeengine/v2/packages` with `id` and `version` (for example `1.0.1`) in the request body, including code/manifest payload.
+3. Update an existing package version: `PUT /api/codeengine/v2/packages/{id}/versions/{version}`
+4. If update fails because the target version is deployed/immutable, create a new version and then update that new version.
+
+Execution notes:
+
+- For new-version creation, prefer creating the version with full code+manifest payload immediately.
+- Use `PUT` for subsequent changes to that specific version.
 
 Always emit resulting `packageId` and `version` for downstream manifest sync.
 


### PR DESCRIPTION
## Summary
- add explicit release safety rules so Code Engine release endpoints are only used after a direct user request to "release"
- clarify create and update semantics for new packages, new versions, and existing version updates
- require post-create verification and document fallback to `code-engine-update` when a created version is incomplete
- expand checklists to cover release gating, verification, and re-verification

## Testing
- Not run (not requested)