### PR TITLE
html-deck: make has-bg mandatory default, fix vertical centering

### DIFF
--- a/skills/documents/html-deck/SKILL.md
+++ b/skills/documents/html-deck/SKILL.md
@@ -37,7 +37,7 @@ Deck Build Progress:
 **Do not skip this step.** Copy the complete skeleton from the theme file, then build slides into it. Every content slide MUST have:
 
 - **Header**: `<div class="slide-header">` with `<h1>`, `.subtitle`, and **`.header-line`** (thin gray separator — required)
-- **Content**: `<div class="slide-content">` (use `has-bg` class for gray `#DDE5ED` background, omit for white)
+- **Content**: `<div class="slide-content has-bg">` — **always use `has-bg`** for the gray `#DDE5ED` background (this is the Domo look; content is vertically centered automatically)
 - **Footer**: `<div class="slide-footer">` with `.confidential` (left), `.footer-line` (center), and `.domo-badge` with **`<img src="LOGO_DATA_URI">`** (bottom-right — required)
 
 ### Dimensions
@@ -46,7 +46,7 @@ Standard 16:9 widescreen: `--slide-w: 1024px; --slide-h: 576px;`
 
 ### Content area positioning
 
-Use `position:absolute` with `top` (below header, typically `90-100px`) and `bottom:52px` (above footer). This prevents content-footer overlap.
+The `has-bg` class handles positioning automatically (`position:absolute; top:90px; bottom:52px`) with vertical centering (`display:flex; justify-content:center`). Do not override these with inline styles.
 
 ## Phase 2 — Content population
 

--- a/skills/documents/html-deck/references/domo-theme.md
+++ b/skills/documents/html-deck/references/domo-theme.md
@@ -325,7 +325,7 @@ body {
 
 ## Complete Skeleton HTML
 
-Copy this entire HTML file as your starting point. It produces two slides matching the Domo Template exactly — one with gray background, one without. Replace every `LOGO_DATA_URI` with the contents of `assets/logo-data-uri.txt`.
+Copy this entire HTML file as your starting point. **Every content slide uses `has-bg` (gray background) by default.** This is the Domo slide look — do NOT use plain white slides unless specifically requested. Content is automatically vertically centered. Replace every `LOGO_DATA_URI` with the contents of `references/assets/logo-data-uri.txt`.
 
 ```html
 <!DOCTYPE html>
@@ -341,7 +341,7 @@ Copy this entire HTML file as your starting point. It produces two slides matchi
 </head>
 <body>
 
-<!-- SLIDE: Content slide WITH gray background (default for most slides) -->
+<!-- SLIDE: Standard content slide — USE THIS FOR EVERY CONTENT SLIDE -->
 <div class="slide">
   <div class="slide-header">
     <h1>Slide Title</h1>
@@ -349,26 +349,7 @@ Copy this entire HTML file as your starting point. It produces two slides matchi
     <div class="header-line"></div>
   </div>
   <div class="slide-content has-bg">
-    <!-- Content goes here — #DDE5ED gray background -->
-  </div>
-  <div class="slide-footer">
-    <span class="confidential">Confidential</span>
-    <span class="footer-line"></span>
-    <span class="domo-badge">
-      <img src="LOGO_DATA_URI" alt="Domo">
-    </span>
-  </div>
-</div>
-
-<!-- SLIDE: Content slide WITHOUT gray background (white) -->
-<div class="slide">
-  <div class="slide-header">
-    <h1>Slide Title</h1>
-    <div class="subtitle">SLIDE SUBTITLE OR DESCRIPTION</div>
-    <div class="header-line"></div>
-  </div>
-  <div class="slide-content" style="position:absolute; top:100px; left:0; right:0; bottom:52px; padding:24px 40px;">
-    <!-- Content goes here — white background -->
+    <!-- Content is vertically centered in the #DDE5ED gray area automatically -->
   </div>
   <div class="slide-footer">
     <span class="confidential">Confidential</span>
@@ -390,7 +371,7 @@ Every content slide MUST have all three layers. Missing any one breaks the layou
 | Layer | Element | Purpose |
 |-------|---------|---------|
 | **Header** | `<div class="slide-header">` with `<h1>`, `.subtitle`, and **`.header-line`** | Title + blue subtitle + thin gray separator |
-| **Content** | `<div class="slide-content">` (add `has-bg` class for gray background) | Main body between header and footer |
+| **Content** | `<div class="slide-content has-bg">` — **always use `has-bg`** | Gray background, vertically centered content |
 | **Footer** | `<div class="slide-footer">` with `.confidential`, `.footer-line`, `.domo-badge` + `<img>` | "CONFIDENTIAL" left, gray line center, **Domo logo bottom-right** |
 
 **The `.header-line` div is required** — it produces the thin gray separator visible in every slide.
@@ -446,10 +427,11 @@ To show a page number above the logo in the footer:
 </span>
 ```
 
-## When to Use `has-bg` vs Plain White
+## `has-bg` Is the Default — Always
 
-- **`has-bg`** (gray background `#DDE5ED`): Default for most content slides — tables, cards, diagrams, info boxes.
-- **Plain white**: Text-heavy slides, screenshot showcases, or when content needs maximum contrast.
+**Use `has-bg` on every content slide.** This is the Domo branded look — the gray `#DDE5ED` content area with vertically centered content. The `has-bg` class provides `position:absolute`, correct `top`/`bottom` bounds, `display:flex`, `flex-direction:column`, and `justify-content:center` automatically.
+
+Do NOT use plain white slides unless the user explicitly requests it. The wealth-deck and initiatives-deck examples both demonstrate that every content slide should have the gray background.
 
 ## Accent Color Reference
 


### PR DESCRIPTION
## Summary

- Makes `has-bg` (gray background) the **mandatory default** for every content slide — removes the white variant from the skeleton entirely
- Ensures content is always vertically centered via the existing `justify-content: center` in the `has-bg` class

## Problem

Real-world usage (wealth-deck built on another machine) revealed two issues:

| Issue | Root cause |
|-------|-----------|
| Content not vertically centered on slides | The AI chose the white slide variant from the skeleton, which had no `display:flex` / `justify-content:center` |
| Gray background never used | The skill presented `has-bg` as optional ("use for gray, omit for white"), so the AI always defaulted to plain white |

## What changed

- **`references/domo-theme.md`**: Removed the white slide variant from the skeleton — only the `has-bg` slide remains as THE standard. Updated the anatomy table and "when to use" section to say "always use `has-bg`" with no opt-out language.
- **`SKILL.md`**: Phase 1 bullet now says "always use `has-bg`" instead of "optionally add `has-bg`". Content area positioning section clarifies that `has-bg` handles positioning and centering automatically.

## Test plan

- [ ] Build a deck on a fresh machine — verify every content slide has gray `#DDE5ED` background
- [ ] Verify content is vertically centered on all slides (especially sparse slides with few elements)

Made with [Cursor](https://cursor.com)