### PR TITLE
docs(code-engine): add global package function discovery guidance

### DIFF
--- a/skills/apps/code-engine/SKILL.md
+++ b/skills/apps/code-engine/SKILL.md
@@ -141,7 +141,45 @@ async function executeFunction(alias: string, payload: Record<string, unknown>) 
 }
 ```
 
+## Discovering function names on global Domo packages
+
+When calling a **Domo-provided global package** (e.g. DOMO Notifications, DOMO DataSets, DOMO Users),
+the exported function names and their exact parameter signatures are not discoverable via the REST API
+— `GET /api/codeengine/v2/packages/{id}/versions/{v}` returns `"functions": []` for all global packages.
+
+**How to find them:** navigate to the package source in the Domo UI:
+
+```
+https://{instance}.domo.com/codeengine/{packageId}
+```
+
+This opens the Code Engine editor showing the full JavaScript source for the package. Read it to find:
+- Exact exported function names (e.g. `sendEmail`, `sendBuzzRequest`)
+- Positional parameter names and order (Code Engine maps by **position**, not key name)
+- Which parameters are optional / nullable
+
+> **Why this matters:** guessing function names against the API returns 404 for every wrong name,
+> giving no indication of what the correct name is. Without reading the source first, you will
+> burn multiple round-trips and may need the user to paste the source manually.
+
+### Example — DOMO Notifications (`03ba6971-98d0-4654-9bfd-aa897816df33`)
+
+Key functions found in source:
+
+| Function | Parameters (positional) | Notes |
+|---|---|---|
+| `sendEmail` | `recipientEmails, subject, body, personRecipients, groupRecipients, attachments, attachment, includeReplyAll` | `recipientEmails` is a single comma-separated string, not an array |
+| `sendEmailToListOfEmails` | `to, subject, body, attachments, attachment, includeReplyAll` | `to` is an array of strings |
+| `sendBuzzRequest` | `channelId, message` | `channelId` must be a valid UUID |
+| `sendExternalEmail` | `to, subject, body, attachments, attachment, includeReplyAll` | Validates against authorized domain whitelist |
+
+> **Gotcha:** `sendEmail` takes `recipientEmails` as a plain string (e.g. `"user@example.com"`),
+> not an array. Passing an array causes silent failure or incorrect routing.
+
 ## Checklist
+- [ ] Read package source at `https://{instance}.domo.com/codeengine/{packageId}` before writing any call
+- [ ] Exact function name confirmed from source (do not guess)
+- [ ] Parameter names and types confirmed from source JSDoc comments
 - [ ] Calls use `domo.post('/domo/codeengine/v2/packages/{alias}', params)` pattern
 - [ ] Manifest uses `packagesMapping` (not `packageMapping`)
 - [ ] `packagesMapping.version` is explicitly pinned when deterministic package behavior is required


### PR DESCRIPTION
## What changed
Added a new section "Discovering function names on global Domo packages" and updated the checklist to require reading package source before writing any Code Engine call.

## Why
When calling global Domo-provided packages (e.g. DOMO Notifications), the REST API returns `"functions": []` for all versions — there is no programmatic way to discover exported function names or their signatures. Without this guidance, agents guess function names against the API, receive 404 on every attempt, and ultimately require the user to manually paste the package source to unblock.

This was discovered during a real integration (Dataset Lineage app, DOMO Notifications sendEmail) where multiple round-trips and user intervention were needed before the call worked.

## How to use it
Navigate to `https://{instance}.domo.com/codeengine/{packageId}` to read the full package source before writing any call. The section also documents the DOMO Notifications function table as a worked example, including a gotcha: `sendEmail` takes `recipientEmails` as a plain string, not an array.

## Checklist addition
"Read package source before writing any call" is now the first checklist item, ensuring this step is never skipped.