### PR TITLE
Add new datagen skill to match CLI

### DIFF
--- a/skills/datagen/domo-data-generator/SKILL.md
+++ b/skills/datagen/domo-data-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: domo-data-generator
-description: "**Generating sample data for Domo** -- invoke when a user needs to create realistic sample datasets and upload them to a Domo instance. Primary signals: requests for sample data, demo data, test data, fake data for Domo; mentions of Salesforce, Google Analytics, QuickBooks, NetSuite, Google Ads, Facebook Ads, or HubSpot sample data; questions about the datagen CLI or domo_data_generator. Covers: generating datasets, uploading to Domo, creating datasets in Domo, rolling dates, entity pools, connector icons, catalog management, and adding new dataset definitions. Skip for: real connector setup, production data pipelines, data transformations (Magic ETL), or Domo App Platform."
+description: "**Generating sample data for Domo** -- invoke when a user needs to create realistic sample datasets and upload them to a Domo instance. Primary signals: requests for sample data, demo data, test data, fake data for Domo; mentions of Salesforce, Google Analytics, QuickBooks, NetSuite, Google Ads, Facebook Ads, HubSpot, Marketo, or Health Portal sample data; questions about the datagen CLI or domo_data_generator. Covers: generating datasets, uploading to Domo, creating datasets in Domo, rolling dates, entity pools, connector icons, catalog management, and adding new dataset definitions. Skip for: real connector setup, production data pipelines, data transformations (Magic ETL), or Domo App Platform."
 ---
 
 # Domo Sample Data Generator
 
-Generate realistic, cross-referenced sample data for Domo using the `domo_data_generator` CLI.
+Generate realistic, cross-referenced sample data for Domo using the `datagen` CLI.
 
 **Repository:** <https://github.com/brrink/domo_data_generator>
 
@@ -15,60 +15,82 @@ Generate realistic, cross-referenced sample data for Domo using the `domo_data_g
 
 The generator creates sample data mirroring major business platforms with consistent cross-source entity integrity, then uploads it to Domo. It includes:
 
-- 10 pre-built datasets across 4 source categories (Salesforce, Google Analytics, Financial, Marketing)
+- 18 pre-built datasets across 6 source categories (Salesforce, Google Analytics, Financial, Marketing, Health, AdPoint)
 - YAML-driven catalog for easy dataset additions
 - Shared entity pool (companies, people, products, sales reps, campaigns)
 - Date rolling to keep data looking current
 - Direct Domo integration (create datasets, upload, set connector icons)
-- Cron-friendly for scheduled automation
+- Structured JSON output by default (AI-agent-friendly)
+- pipx installable -- runs from any directory
 
 ---
 
 ## Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/brrink/domo_data_generator.git
-cd domo_data_generator
+# Install globally with pipx (recommended)
+pipx install git+https://github.com/brrink/domo_data_generator.git
 
-# Create virtual environment and install dependencies
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+# Initialize a working directory
+mkdir my-domo-data && cd my-domo-data
+datagen init
 
-# Configure environment
-cp .env.example .env
 # Edit .env with your Domo credentials
 ```
 
 ### Required Environment Variables
 
-| Variable | Purpose |
-|----------|---------|
-| `DOMO_CLIENT_ID` | OAuth client identifier |
-| `DOMO_CLIENT_SECRET` | OAuth client secret |
-| `DOMO_DEVELOPER_TOKEN` | Internal API auth token |
-| `DOMO_API_HOST` | API endpoint hostname |
-| `DOMO_INSTANCE` | Domo instance name |
-| `DOMO_SET_CONNECTOR_TYPE` | Enable connector icon customization (optional, default: false) |
+Edit the `.env` file created by `datagen init`:
+
+| Variable | Purpose | Required for |
+|----------|---------|-------------|
+| `DOMO_INSTANCE` | Domo instance name (e.g. `mycompany`) | All Domo operations |
+| `DOMO_DEVELOPER_TOKEN` | Access token from Domo Admin | Connector icons, provider discovery |
+| `DOMO_CLIENT_ID` | OAuth client ID | Dataset creation, data upload |
+| `DOMO_CLIENT_SECRET` | OAuth client secret | Dataset creation, data upload |
+
+To create OAuth client credentials: **Domo > Admin > Authentication > Client credentials** -- create a client with `data` and `dashboard` scopes.
+
+To create a developer token: **Domo > Admin > Authentication > Access tokens**.
+
+Offline commands (`generate`, `list`, `status`, `pool`, `roll-dates`, `init`) require no credentials.
 
 ---
 
 ## CLI Reference
 
-Entry point: `python -m datagen [OPTIONS] COMMAND [ARGS]`
+Entry point: `datagen [OPTIONS] COMMAND [ARGS]`
 
-Global option: `--verbose / -v` enables verbose logging.
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--verbose / -v` | Enable verbose logging |
+| `--output / -o TEXT` | Output format: `json` (default), `table`, `yaml` |
+| `--yes / -y` | Skip confirmation prompts |
+
+All commands emit structured JSON by default for easy machine parsing.
+
+### Init Command
+
+#### `init` -- Initialize a working directory
+
+```bash
+datagen init                  # Initialize current directory
+datagen init /path/to/dir     # Initialize a specific directory
+```
+
+Copies bundled catalog YAML files to `./catalog/`, creates `.env` template, and creates `./data/` directory. Run this once before using the CLI in a new directory.
 
 ### Core Commands
 
 #### `generate` -- Generate sample data
 
 ```bash
-python -m datagen generate --all                    # Generate all datasets
-python -m datagen generate salesforce_opportunities  # Generate one dataset
-python -m datagen generate --all --seed 42          # Reproducible generation
-python -m datagen generate --all --dry-run          # Preview without writing
+datagen generate --all                    # Generate all datasets
+datagen generate salesforce_opportunities  # Generate one dataset
+datagen generate --all --seed 42          # Reproducible generation
+datagen generate --all --dry-run          # Preview without writing
 ```
 
 | Option | Description |
@@ -83,9 +105,11 @@ python -m datagen generate --all --dry-run          # Preview without writing
 #### `upload` -- Upload data to Domo (full replace)
 
 ```bash
-python -m datagen upload --all
-python -m datagen upload salesforce_opportunities
+datagen upload --all
+datagen upload salesforce_opportunities
 ```
+
+Requires `DOMO_CLIENT_ID` and `DOMO_CLIENT_SECRET`.
 
 | Option | Description |
 |--------|-------------|
@@ -97,9 +121,11 @@ python -m datagen upload salesforce_opportunities
 #### `create-dataset` -- Create dataset(s) in Domo from catalog
 
 ```bash
-python -m datagen create-dataset --all --skip-existing
-python -m datagen create-dataset salesforce_opportunities
+datagen create-dataset --all --skip-existing
+datagen create-dataset salesforce_opportunities
 ```
+
+Requires `DOMO_CLIENT_ID` and `DOMO_CLIENT_SECRET`. The `domo_id` is persisted locally (in the catalog YAML if writable, otherwise in `data/domo_ids.json`).
 
 | Option | Description |
 |--------|-------------|
@@ -111,8 +137,8 @@ python -m datagen create-dataset salesforce_opportunities
 #### `roll-dates` -- Shift rolling date columns to stay current
 
 ```bash
-python -m datagen roll-dates
-python -m datagen roll-dates --anchor-date 2026-04-01
+datagen roll-dates
+datagen roll-dates --anchor-date 2026-04-01
 ```
 
 | Option | Description |
@@ -126,35 +152,38 @@ python -m datagen roll-dates --anchor-date 2026-04-01
 #### `list` -- List catalog dataset definitions
 
 ```bash
-python -m datagen list
-python -m datagen list --verbose   # Show column details
+datagen list                    # JSON output (default)
+datagen --output table list     # Rich table for humans
+datagen list --verbose          # Include column/schema details
 ```
 
 #### `status` -- Display generation status for all datasets
 
 ```bash
-python -m datagen status
+datagen status
 ```
 
 ### Connector Icon Commands
 
+Require `DOMO_DEVELOPER_TOKEN` and `DOMO_INSTANCE`.
+
 #### `discover-types` -- Search Domo connector/provider types
 
 ```bash
-python -m datagen discover-types salesforce
+datagen discover-types salesforce
 ```
 
 #### `set-type` -- Set connector icon on a Domo dataset
 
 ```bash
-python -m datagen set-type salesforce_opportunities
-python -m datagen set-type salesforce_opportunities --provider-key custom_key
+datagen set-type salesforce_opportunities
+datagen set-type salesforce_opportunities --provider-key custom_key
 ```
 
 #### `set-type-all` -- Set connector icon on all datasets with a `domo_id`
 
 ```bash
-python -m datagen set-type-all
+datagen set-type-all
 ```
 
 ### Entity Pool Commands
@@ -162,9 +191,9 @@ python -m datagen set-type-all
 #### `pool regenerate` -- Regenerate the shared entity pool
 
 ```bash
-python -m datagen pool regenerate
-python -m datagen pool regenerate --seed 99
-python -m datagen pool regenerate --company-count 500 --person-count 1000
+datagen pool regenerate
+datagen pool regenerate --seed 99
+datagen pool regenerate --company-count 500 --person-count 1000
 ```
 
 | Option | Default |
@@ -179,7 +208,7 @@ python -m datagen pool regenerate --company-count 500 --person-count 1000
 #### `pool show` -- Display entity pool summary
 
 ```bash
-python -m datagen pool show
+datagen pool show
 ```
 
 ---
@@ -189,39 +218,55 @@ python -m datagen pool show
 ### Full setup for a new Domo instance
 
 ```bash
-python -m datagen pool regenerate
-python -m datagen generate --all
-python -m datagen create-dataset --all
-python -m datagen upload --all
-python -m datagen set-type-all
+datagen init
+# Edit .env with credentials
+datagen pool regenerate
+datagen generate --all
+datagen create-dataset --all
+datagen upload --all
+datagen set-type-all
 ```
 
 ### Daily refresh via cron
 
 ```bash
 # Crontab entry: roll dates and re-upload daily at 6 AM
-0 6 * * * cd /path/to/domo_data_generator && .venv/bin/python -m datagen roll-dates && .venv/bin/python -m datagen upload --all
+0 6 * * * cd /path/to/project && datagen roll-dates && datagen upload --all
 ```
 
 ### Generate a single dataset end-to-end
 
 ```bash
-python -m datagen generate salesforce_opportunities
-python -m datagen create-dataset salesforce_opportunities
-python -m datagen upload salesforce_opportunities
-python -m datagen set-type salesforce_opportunities
+datagen generate salesforce_opportunities
+datagen create-dataset salesforce_opportunities
+datagen upload salesforce_opportunities
+datagen set-type salesforce_opportunities
 ```
 
 ---
 
 ## Included Datasets
 
-| Category | Dataset Name |
-|----------|-------------|
-| Salesforce | `salesforce_accounts`, `salesforce_contacts`, `salesforce_opportunities` |
-| Google Analytics | `ga_sessions`, `ga_pageviews` |
-| Financial | `financial_gl_entries`, `financial_invoices` |
-| Marketing | `marketing_google_ads`, `marketing_facebook_ads`, `marketing_hubspot_contacts` |
+| Category | Dataset Name | Key | Rows |
+|----------|-------------|-----|------|
+| Salesforce | Salesforce - Accounts | `salesforce_accounts` | 500 |
+| Salesforce | Salesforce - Contacts | `salesforce_contacts` | 1,500 |
+| Salesforce | Salesforce - Opportunities | `salesforce_opportunities` | 2,500 |
+| Google Analytics | Google Analytics - Sessions | `ga_sessions` | 5,000 |
+| Google Analytics | Google Analytics - Page Views | `ga_pageviews` | 10,000 |
+| Financial | QuickBooks - Invoices | `financial_invoices` | 3,000 |
+| Financial | NetSuite - General Ledger | `financial_gl_entries` | 5,000 |
+| Marketing | Google Ads - Campaign Performance | `marketing_google_ads` | 3,000 |
+| Marketing | Facebook Ads - Campaign Performance | `marketing_facebook_ads` | 2,500 |
+| Marketing | HubSpot - Contacts | `marketing_hubspot_contacts` | 2,000 |
+| Marketing | Marketing - Market Leads | `marketing_market_leads` | 2,500 |
+| Marketing | Marketo - Leads | `marketing_marketo_leads` | 3,000 |
+| Health | Health Portal - Demographics | `health_demographics` | 15 |
+| Health | Health Portal - Lab Results | `health_lab_results` | 1,470 |
+| Health | Health Portal - Vitals | `health_vitals` | 5,250 |
+| AdPoint | AdPoint - Orders | `adpoint_orders` | 150 |
+| AdPoint | AdPoint - Line Items | `adpoint_line_items` | 500 |
+| AdPoint | AdPoint - Flights | `adpoint_flights` | 2,000 |
 
 ---
 
@@ -246,8 +291,9 @@ Dataset definitions live in the `catalog/` directory as YAML files. Each YAML fi
 ### YAML Structure
 
 ```yaml
-meta:
-  name: my_custom_dataset
+dataset:
+  name: My Custom Dataset
+  domo_id: null
   source_type: custom
   description: "Description of the dataset"
   row_count: 1000
@@ -255,7 +301,7 @@ meta:
     - custom
     - demo
 
-columns:
+schema:
   - name: id
     type: STRING
     generator: uuid4
@@ -297,6 +343,8 @@ columns:
 
 **Marketing/Ads:** `ad_platform`, `campaign_objective`, `ad_format`, `ad_headline`, `ad_keyword`, `targeting_type`, `impressions`, `clicks_from_impressions`, `ctr`, `cost_per_click`, `ad_spend`, `conversions_from_clicks`, `hubspot_lifecycle`, `hubspot_lead_status`, `ad_group_id`
 
+**Health:** `health_lab_init`, `health_lab_field`, `health_vital_init`, `health_vital_field`, `health_demographics`
+
 ### Generator Column Options
 
 | Option | Used With | Description |
@@ -320,23 +368,26 @@ columns:
 
 ## Rules
 
-1. **Always generate before uploading** -- Run `generate` (or `generate --all`) before `upload` to ensure data files exist.
-2. **Create datasets before first upload** -- Run `create-dataset` before `upload` for new datasets. The `domo_id` is stored in the catalog YAML.
-3. **Use `--skip-existing`** -- When running `create-dataset --all`, use `--skip-existing` to avoid duplicating datasets that already have a `domo_id`.
-4. **Entity pool consistency** -- Regenerating the pool (`pool regenerate`) invalidates all previously generated data. Re-generate all datasets afterward.
-5. **Date rolling** -- Use `roll-dates` before upload to keep date columns current. Only columns with `rolling: true` are affected.
-6. **Environment variables** -- Ensure `.env` is configured before any Domo operations (`upload`, `create-dataset`, `set-type`).
-7. **Reproducibility** -- Use `--seed` for reproducible data generation across runs.
+1. **Run `datagen init` first** -- Initialize a working directory before using any other commands. This copies the catalog and creates `.env`.
+2. **Always generate before uploading** -- Run `generate` (or `generate --all`) before `upload` to ensure CSV data files exist.
+3. **Create datasets before first upload** -- Run `create-dataset` before `upload` for new datasets. The `domo_id` is persisted locally.
+4. **Use `--skip-existing`** -- When running `create-dataset --all`, use `--skip-existing` to avoid duplicating datasets that already have a `domo_id`.
+5. **Entity pool consistency** -- Regenerating the pool (`pool regenerate`) invalidates all previously generated data. Re-generate all datasets afterward.
+6. **Date rolling** -- Use `roll-dates` before upload to keep date columns current. Only columns with `rolling: true` are affected.
+7. **Credentials** -- `DOMO_CLIENT_ID` and `DOMO_CLIENT_SECRET` are required for `upload` and `create-dataset`. `DOMO_DEVELOPER_TOKEN` is required for `set-type` and `discover-types`. Offline commands need no credentials.
+8. **Reproducibility** -- Use `--seed` for reproducible data generation across runs.
+9. **Output format** -- Default output is JSON. Use `--output table` for human-readable Rich tables.
 
 ---
 
 ## Checklist
 
-- [ ] Repository cloned and dependencies installed
-- [ ] `.env` configured with valid Domo credentials
-- [ ] Entity pool generated (`pool regenerate`)
-- [ ] Datasets generated (`generate --all`)
-- [ ] Datasets created in Domo (`create-dataset --all --skip-existing`)
-- [ ] Data uploaded (`upload --all`)
-- [ ] Connector icons set (`set-type-all`) if desired
+- [ ] CLI installed (`pipx install git+https://github.com/brrink/domo_data_generator.git`)
+- [ ] Working directory initialized (`datagen init`)
+- [ ] `.env` configured with Domo credentials
+- [ ] Entity pool generated (`datagen pool regenerate`)
+- [ ] Datasets generated (`datagen generate --all`)
+- [ ] Datasets created in Domo (`datagen create-dataset --all --skip-existing`)
+- [ ] Data uploaded (`datagen upload --all`)
+- [ ] Connector icons set (`datagen set-type-all`) if desired
 - [ ] Cron configured for daily date rolling and upload if needed


### PR DESCRIPTION
 Update domo-data-generator skill for refactored CLI

  Summary

  - Rewrite SKILL.md to reflect the refactored datagen CLI (v0.1.0)
  - Install method changed from git clone + venv to pipx install
  - Entry point changed from python -m datagen to datagen
  - Auth model updated: developer token (instance API) + OAuth client credentials (data upload)
  - Removed stale env vars: DOMO_API_HOST, DOMO_SET_CONNECTOR_TYPE
  - Added datagen init command and --output json|table|yaml / --yes global flags
  - Fixed YAML structure example (dataset:/schema: instead of incorrect meta:/columns:)
  - Updated dataset catalog: 10 datasets -> 18 across 6 categories (added Health, AdPoint, Marketo)
  - Added health generators to generator reference

  Context

  The upstream CLI repo (brrink/domo_data_generator) was refactored to be pipx-installable with structured JSON output for AI-agent consumption.
  This skill update aligns the documentation with how the CLI actually works now.