### PR TITLE
Docs: align skill paths (demo-skills, app-studio, custom-apps); drop …

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Domo is a broad platform — "data query" means something completely different w
 
 | Directory | Scope |
 |-----------|-------|
-| `apps/` | Domo App Platform custom apps |
-| `visualization/` | App Studio, pro-code visualizations, and native card creation |
+| `custom-apps/` | Domo App Platform custom apps (`domo.js`, Query, toolkit, AppDB, publish, migrations, filesets, …) |
+| `app-studio/` | App Studio: CLI + layouts, native cards, beast modes, variables, pro-code, demo capture (`basic-app-studio` vs `advanced-app-studio`) |
 | `domo-everywhere/` | Embedding Domo content in external applications |
 | `connectors/` | Custom Connector IDE and data upload tools |
-| `orchestrator-skills/` | End-to-end orchestration runbooks that reference other skills in order |
+| `(demo-skills)/` | End-to-end orchestration runbooks that reference other skills in order |
 | `documents/` | Document and slide deck generation |
 | `cli/` | Command-line tooling and lifecycle workflows |
 | `themes/` | UI theme reference, design tokens, and color palettes |
@@ -61,18 +61,19 @@ Domo is a broad platform — "data query" means something completely different w
 
 More directories can be added as new skills are contributed.
 
-### Orchestrator skills vs. skills
+### Demo skills vs. other skills
 
-**Orchestrator skills** are end-to-end orchestration skills that reference sub-skills to perform many Domo operations in sequence (e.g. building an app from scratch). Regular skills are atomic — one API, one tool, one concept. Orchestrator skills compose them.
+**Demo skills** (`skills/(demo-skills)/`) are end-to-end orchestration runbooks that reference sub-skills to perform many Domo operations in sequence (e.g. building an app from scratch). Regular skills are atomic — one API, one tool, one concept. Demo skills compose them.
 
 ## Available Skills
 
-### Orchestrator Skills (`skills/orchestrator-skills/`)
+### Demo skills (`skills/(demo-skills)/`)
 
 - `basic-app-build` — Kickoff sequence for new Domo app builds; routes to the right rules and skills in order.
 - `basic-app-build-w-video` — `basic-app-build` plus Remotion-oriented styling, sample data, and a short demo video phase.
+- `app-studio-demo` — Micro-demo App Studio app (pages, theme, heroes, native cards, layout) using `advanced-app-studio` + `domo-app-theme`.
 
-### Apps (`skills/apps/`)
+### Custom apps (`skills/custom-apps/`)
 
 - `da-cli` — Recommended for advanced users using DA CLI; ask your agent to use this skill for advanced scaffolding, generation, and manifest instance workflows.
 - `publish` — Build and publish flow (`npm run build`, `cd dist`, `domo publish`).
@@ -87,6 +88,7 @@ More directories can be added as new skills are contributed.
 - `manifest` — `manifest.json` mapping requirements and gotchas.
 - `sql-query` — SqlClient raw SQL query patterns and response parsing.
 - `performance` — Data query performance rules.
+- `fileset-api` — Filesets API usage from custom apps.
 - `migrate-lovable` — Convert SSR-heavy generated apps to Domo-compatible client apps.
 - `migrate-googleai` — Convert AI Studio-origin projects to Domo static deploy contract.
 
@@ -101,9 +103,10 @@ More directories can be added as new skills are contributed.
 
 - `html-deck` — Build HTML slide decks from source content and convert to pixel-perfect PDF via Puppeteer.
 
-### Visualization (`skills/visualization/`)
+### App Studio (`skills/app-studio/`)
 
-- `app-studio` — App Studio REST API: apps, views, layouts, cards, theming.
+- `basic-app-studio` — Lean `community-domo-cli` command surface for App Studio CRUD (no deep reference tables).
+- `advanced-app-studio` — Full App Studio reference: CLI examples, layouts, card styles, themes, variables, gotchas.
 - `app-studio-pro-code` — Pro-code custom apps embedded in App Studio (filters, variables, charts).
 - `app-studio-demo-capture` — Playwright-based capture workflow for polished walkthrough videos of deployed App Studio apps.
 - `card-creation` — Native KPI/card CRUD via Product API.
@@ -122,6 +125,7 @@ More directories can be added as new skills are contributed.
 - `code-engine-update` — CLI-first Code Engine package update/version workflows and drift synchronization.
 - `appdb-collection-create` — CLI-first AppDB collection creation workflow that includes required datastore provisioning.
 - `community-cli-howto` — Community Domo CLI usage, endpoint testing, and ryuu-session auth configuration.
+- `filesets` — Filesets CLI patterns and workflows.
 
 ### Themes (`skills/themes/`)
 
@@ -145,8 +149,30 @@ Each skill is a folder with a single entrypoint `SKILL.md` (supporting files liv
 
 ```text
 skills/
+├── (demo-skills)/
+│   ├── app-studio-demo/SKILL.md
+│   ├── basic-app-build/SKILL.md
+│   └── basic-app-build-w-video/SKILL.md
 ├── administration/workspaces/SKILL.md
-├── apps/
+├── app-studio/
+│   ├── advanced-app-studio/SKILL.md
+│   ├── app-studio-demo-capture/SKILL.md
+│   ├── app-studio-pro-code/SKILL.md
+│   ├── basic-app-studio/SKILL.md
+│   ├── beast-mode-creation/SKILL.md
+│   ├── card-creation/SKILL.md
+│   └── variable-creation/SKILL.md
+├── cli/
+│   ├── appdb-collection-create/SKILL.md
+│   ├── code-engine-create/SKILL.md
+│   ├── code-engine-update/SKILL.md
+│   ├── community-cli-howto/SKILL.md
+│   └── filesets/SKILL.md
+├── connectors/
+│   ├── connector-dev/SKILL.md
+│   ├── data-upload-java-cli/SKILL.md
+│   └── json-no-code-connector/SKILL.md
+├── custom-apps/
 │   ├── ai-service-layer/SKILL.md
 │   ├── appdb/SKILL.md
 │   ├── code-engine/SKILL.md
@@ -154,6 +180,7 @@ skills/
 │   ├── data-api/SKILL.md
 │   ├── dataset-query/SKILL.md
 │   ├── domo-js/SKILL.md
+│   ├── fileset-api/SKILL.md
 │   ├── manifest/SKILL.md
 │   ├── migrate-googleai/SKILL.md
 │   ├── migrate-lovable/SKILL.md
@@ -162,15 +189,6 @@ skills/
 │   ├── sql-query/SKILL.md
 │   ├── toolkit/SKILL.md
 │   └── workflow/SKILL.md
-├── cli/
-│   ├── appdb-collection-create/SKILL.md
-│   ├── code-engine-create/SKILL.md
-│   ├── code-engine-update/SKILL.md
-│   └── community-cli-howto/SKILL.md
-├── connectors/
-│   ├── connector-dev/SKILL.md
-│   ├── data-upload-java-cli/SKILL.md
-│   └── json-no-code-connector/SKILL.md
 ├── datagen/domo-data-generator/SKILL.md
 ├── documents/html-deck/SKILL.md
 ├── domo-everywhere/
@@ -178,18 +196,8 @@ skills/
 │   ├── embed-portal/SKILL.md
 │   ├── jsapi-filters/SKILL.md
 │   └── programmatic-filters/SKILL.md
-├── orchestrator-skills/
-│   ├── basic-app-build/SKILL.md
-│   └── basic-app-build-w-video/SKILL.md
 ├── themes/domo-app-theme/SKILL.md
-├── transformation/magic-etl/SKILL.md
-└── visualization/
-    ├── app-studio/SKILL.md
-    ├── app-studio-demo-capture/SKILL.md
-    ├── app-studio-pro-code/SKILL.md
-    ├── beast-mode-creation/SKILL.md
-    ├── card-creation/SKILL.md
-    └── variable-creation/SKILL.md
+└── transformation/magic-etl/SKILL.md
 
 rules/
 ├── core-custom-apps-rule.md
@@ -258,5 +266,5 @@ If that happens, ask your agent to manually copy the specific `skills/<feature>/
   - `domo-card-crud.md`
   - `chart_type_options_complete.json`
   - `skills/documents/html-deck/references/assets/domologo.png`
-- Keep `basic-app-build` as the canonical orchestrator skill name across docs and skills.
+- Keep `basic-app-build` as the canonical demo skill name across docs and skills.
 - `ryuu.js` filter listener naming changed across versions (`onFiltersUpdated` vs `onFiltersUpdate`); current docs include compatibility guidance, but this should be normalized in a later cleanup pass.

--- a/rules/core-custom-apps-rule.md
+++ b/rules/core-custom-apps-rule.md
@@ -27,6 +27,10 @@ alwaysApply: true
 - These skills are **strictly optional helpers**. If the community CLI is not installed or the user does not want to use it, **skip those skills gracefully** and fall back to asking the user to provide the needed IDs/resources manually or perform the step in the Domo UI.
 - Other skills (e.g. `code-engine`, `appdb`) may suggest using a `cli/` skill first. That suggestion is a convenience, not a requirement — it must **never block the build**.
 
+## App Studio vs custom apps
+- **`skills/custom-apps/`** — code that runs *inside* a Domo custom app card (data, AppDB, toolkit, manifest, publish).
+- **`skills/app-studio/`** — building and operating *App Studio* apps (pages, layouts, native KPI cards, variables, beast modes, pro-code iframes). Start with `basic-app-studio` for copy-paste CLI operations; use `advanced-app-studio` for the full layout/theme/reference material.
+
 ## API index
 - Data API
 - AppDB
@@ -37,26 +41,35 @@ alwaysApply: true
 - Files / Filesets / Groups / User / Task Center
 
 ## Skill routing
-- New app build playbook -> `skills/orchestrator-skills/basic-app-build/SKILL.md`
-- Dataset querying -> `skills/apps/dataset-query/SKILL.md`
-- Data API overview -> `skills/apps/data-api/SKILL.md`
-- domo.js usage -> `skills/apps/domo-js/SKILL.md`
-- Toolkit usage -> `skills/apps/toolkit/SKILL.md`
-- AppDB -> `skills/apps/appdb/SKILL.md`
+- New app build playbook -> `skills/(demo-skills)/basic-app-build/SKILL.md`
+- App Studio micro-demo orchestration (pages, theme, heroes) -> `skills/(demo-skills)/app-studio-demo/SKILL.md`
+- Dataset querying -> `skills/custom-apps/dataset-query/SKILL.md`
+- Data API overview -> `skills/custom-apps/data-api/SKILL.md`
+- domo.js usage -> `skills/custom-apps/domo-js/SKILL.md`
+- Toolkit usage -> `skills/custom-apps/toolkit/SKILL.md`
+- AppDB -> `skills/custom-apps/appdb/SKILL.md`
 - Community CLI howto (start here for any CLI skill) -> `skills/cli/community-cli-howto/SKILL.md`
 - AppDB collection create (datastore + collection lifecycle) -> `skills/cli/appdb-collection-create/SKILL.md`
-- AI services -> `skills/apps/ai-service-layer/SKILL.md`
-- Code Engine -> `skills/apps/code-engine/SKILL.md`
+- AI services -> `skills/custom-apps/ai-service-layer/SKILL.md`
+- Code Engine -> `skills/custom-apps/code-engine/SKILL.md`
 - Code Engine package create -> `skills/cli/code-engine-create/SKILL.md`
 - Code Engine package update -> `skills/cli/code-engine-update/SKILL.md`
-- Workflows -> `skills/apps/workflow/SKILL.md`
-- SQL queries -> `skills/apps/sql-query/SKILL.md`
-- Manifest wiring -> `skills/apps/manifest/SKILL.md`
-- Build/publish -> `skills/apps/publish/SKILL.md`
-- DA CLI -> `skills/apps/da-cli/SKILL.md`
-- Performance -> `skills/apps/performance/SKILL.md`
-- Migration from Lovable/v0 -> `skills/apps/migrate-lovable/SKILL.md`
-- Migration from Google AI Studio -> `skills/apps/migrate-googleai/SKILL.md`
+- Workflows -> `skills/custom-apps/workflow/SKILL.md`
+- SQL queries -> `skills/custom-apps/sql-query/SKILL.md`
+- Manifest wiring -> `skills/custom-apps/manifest/SKILL.md`
+- Build/publish -> `skills/custom-apps/publish/SKILL.md`
+- DA CLI -> `skills/custom-apps/da-cli/SKILL.md`
+- Performance -> `skills/custom-apps/performance/SKILL.md`
+- Filesets API -> `skills/custom-apps/fileset-api/SKILL.md`
+- Migration from Lovable/v0 -> `skills/custom-apps/migrate-lovable/SKILL.md`
+- Migration from Google AI Studio -> `skills/custom-apps/migrate-googleai/SKILL.md`
+- App Studio (CLI operations only) -> `skills/app-studio/basic-app-studio/SKILL.md`
+- App Studio (full CLI + reference) -> `skills/app-studio/advanced-app-studio/SKILL.md`
+- App Studio pro-code embedded custom apps -> `skills/app-studio/app-studio-pro-code/SKILL.md`
+- App Studio walkthrough video capture (Playwright) -> `skills/app-studio/app-studio-demo-capture/SKILL.md`
+- Native KPI/card CRUD (Product API) -> `skills/app-studio/card-creation/SKILL.md`
+- Beast modes -> `skills/app-studio/beast-mode-creation/SKILL.md`
+- Card variables / controls -> `skills/app-studio/variable-creation/SKILL.md`
 - Connector IDE -> `skills/connectors/connector-dev/SKILL.md`
 - Programmatic embed filters / dataset switching -> `skills/domo-everywhere/programmatic-filters/SKILL.md`
 - JS API filters -> `skills/domo-everywhere/jsapi-filters/SKILL.md`

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,19 +6,21 @@ Each subfolder here is one skill with a single entrypoint:
 skills/<feature>/<skill-name>/SKILL.md
 ```
 
+Some groups use a parenthetical folder name (valid on disk), e.g. `skills/(demo-skills)/basic-app-build/SKILL.md`.
+
 Current feature groups:
 
+- `(demo-skills)/` — end-to-end orchestration runbooks that pull in other skills in order (`basic-app-build`, `basic-app-build-w-video`, `app-studio-demo`)
 - `administration/`
-- `apps/`
+- `app-studio/` — App Studio (CLI + REST concepts): apps/views/layouts/cards, theme, native cards, beast modes, variables, pro-code embedding, Playwright demo capture; includes **`basic-app-studio`** (lean CLI ops) and **`advanced-app-studio`** (full reference)
+- `custom-apps/` — Domo App Platform custom-app runtime: `domo.js`, `@domoinc/query`, toolkit, AppDB, AI, Code Engine, workflows, manifest, publish, migrations, filesets API, performance
 - `cli/`
 - `connectors/`
 - `datagen/`
 - `documents/`
 - `domo-everywhere/`
-- `orchestrator-skills/`
 - `themes/`
 - `transformation/`
-- `visualization/`
 
 CLI skills currently available:
 
@@ -26,5 +28,6 @@ CLI skills currently available:
 - `cli/code-engine-update`
 - `cli/appdb-collection-create`
 - `cli/community-cli-howto`
+- `cli/filesets`
 
 For installation/discovery and the full catalog, use the root `README.md`.

--- a/skills/cli/appdb-collection-create/SKILL.md
+++ b/skills/cli/appdb-collection-create/SKILL.md
@@ -16,7 +16,7 @@ This skill covers storage initialization lifecycle:
 - capture resulting identifiers
 - prepare follow-up manifest mapping and document-write usage
 
-For document CRUD operations after collection exists, use `skills/apps/appdb/SKILL.md`.
+For document CRUD operations after collection exists, use `skills/custom-apps/appdb/SKILL.md`.
 
 ## Assumed CLI Behavior
 
@@ -85,4 +85,4 @@ After successful creation, ensure app manifest contains collection wiring expect
 - [ ] CLI collection-create path used first
 - [ ] Datastore+collection identifiers captured
 - [ ] Manifest collection mapping follow-up performed
-- [ ] Hand-off to document CRUD flow (`skills/apps/appdb/SKILL.md`) is clear
+- [ ] Hand-off to document CRUD flow (`skills/custom-apps/appdb/SKILL.md`) is clear

--- a/skills/cli/code-engine-create/SKILL.md
+++ b/skills/cli/code-engine-create/SKILL.md
@@ -16,7 +16,7 @@ This skill covers lifecycle operations that are out of scope for app-runtime inv
 - infer and normalize function input/output datatypes
 - update app `manifest.json` `packagesMapping` entries after create
 
-For in-app function invocation patterns, use `skills/apps/code-engine/SKILL.md`.
+For in-app function invocation patterns, use `skills/custom-apps/code-engine/SKILL.md`.
 
 ## Primary Execution Path
 

--- a/skills/cli/code-engine-update/SKILL.md
+++ b/skills/cli/code-engine-update/SKILL.md
@@ -16,7 +16,7 @@ This skill covers:
 - detect and handle mapping drift between package and app manifest
 - validate datatype contract stability
 
-For app-runtime invocation code, use `skills/apps/code-engine/SKILL.md`.
+For app-runtime invocation code, use `skills/custom-apps/code-engine/SKILL.md`.
 
 ## Primary Execution Path
 

--- a/skills/domo-everywhere/embed-portal/SKILL.md
+++ b/skills/domo-everywhere/embed-portal/SKILL.md
@@ -5,7 +5,7 @@ description: "Use for any project where external users need a login to view or i
 
 # Build a Domo Embed Portal
 
-This is an orchestrator skill. It gathers requirements, then delegates to existing capability skills for the Domo-specific implementation details. Do not duplicate content from those skills — read them at the appropriate step.
+This skill runs an end-to-end workflow: it gathers requirements, then delegates to existing capability skills for the Domo-specific implementation details. Do not duplicate content from those skills — read them at the appropriate step.
 
 **Sub-skills used:**
 - `programmatic-filters` — Read-only embed token flow, server-side filters, dataset switching


### PR DESCRIPTION
…orchestrator wording- Update root README, skills/README, and repo tree for new layout

- Refresh core-custom-apps-rule skill routing and App Studio vs custom-apps note
- Point CLI skills at skills/custom-apps/* for cross-links
- embed-portal: replace orchestrator skill phrasing

Made-with: Cursor