### PR TITLE
Normalize skill pathing and finalize update-plan fixes.

### DIFF
--- a/SKILL_UPDATE_PLAN.md
+++ b/SKILL_UPDATE_PLAN.md
@@ -1,0 +1,484 @@
+# Domo Skills — Comprehensive Update Plan
+
+**Date:** 2026-04-12
+**Context:** Produced after a failed manufacturing demo build exposed broken cross-references, CLI confusion, duplicate skills, and content gaps. This file is a complete work order for another agent to execute changes against the **source skill repo** before re-publishing.
+
+---
+
+## Table of Contents
+
+1. [Background](#1-background)
+2. [Part A — Fix all cross-references to use flat installed paths](#2-part-a--fix-all-cross-references-to-use-flat-installed-paths)
+3. [Part B — Add two-CLI boundary rule to core-custom-apps-rule.md](#3-part-b--add-two-cli-boundary-rule)
+4. [Part C — Update core-custom-apps-rule.md skill routing table](#4-part-c--update-skill-routing-table)
+5. [Part D — Remove nested duplicate directories from installed skills](#5-part-d--remove-nested-duplicate-directories)
+6. [Part E — Content fixes from manufacturing demo build](#6-part-e--content-fixes-from-manufacturing-demo-build)
+7. [Verification checklist](#7-verification-checklist)
+
+---
+
+## 1. Background
+
+### Two CLIs exist
+
+
+| CLI                                           | Binary               | Purpose                                                                                                                                                                       |
+| --------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Ryuu** (official Domo CLI, `@domoinc/ryuu`) | `domo`               | `domo login`, `domo dev`, `domo publish` — custom app lifecycle ONLY                                                                                                          |
+| **Community CLI** (`community-domo-cli`)      | `community-domo-cli` | ALL Domo Product API operations — datasets, app-studio, cards, dataflows, appdb, code-engine, filesets, workflows, pages, users, pdp, domoapps, beast-modes, variables, files |
+
+
+The model tried `domo datasets get-schema` (which doesn't exist) instead of `community-domo-cli datasets schema` because:
+
+- The core rule only mentions the community CLI in a "CLI skills are optional" footnote
+- The demo orchestrator skill says "fetch schema" without specifying which CLI
+- The reference files that would have shown the correct CLI couldn't be read because their paths were wrong
+
+### Flat vs nested path problem
+
+Skills are organized in nested directories in the source repo (e.g., `skills/cli/community-cli-howto/`) but `npx skills add` installs them flat (e.g., `~/.agents/skills/community-cli-howto/`). Cross-references written as nested paths fail at runtime.
+
+### Duplicate installations
+
+Nearly every skill exists twice — a flat copy AND a nested copy under `~/.agents/skills/`. Many pairs have DIFFERENT content (the flat copy may be newer). The nested copies are stale remnants that should be removed.
+
+---
+
+## 2. Part A — Fix all cross-references to use flat installed paths
+
+Every path referencing another skill must use the flat format: `~/.agents/skills/<skill-name>/...`
+
+### A1. `app-studio-dataset-etl-gen-demo/SKILL.md` (14 broken refs)
+
+These are the reference file paths in the "Read these helper scripts" section (lines 12-18):
+
+
+| Line | Current (broken)                                                                                 | Replace with                                                                       |
+| ---- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| 12   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/cli_helpers.py`       | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/cli_helpers.py`       |
+| 13   | `~/.agents/skills/app-studio/advanced-app-studio/references/card_templates.py`                   | `~/.agents/skills/advanced-app-studio/references/card_templates.py`                |
+| 14   | `~/.agents/skills/app-studio/advanced-app-studio/references/layout_assembler.py`                 | `~/.agents/skills/advanced-app-studio/references/layout_assembler.py`              |
+| 15   | `~/.agents/skills/themes/domo-app-theme/references/theme_transform.py`                           | `~/.agents/skills/domo-app-theme/references/theme_transform.py`                    |
+| 16   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/theme_loader.py`      | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/theme_loader.py`      |
+| 17   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/vertical_detector.py` | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/vertical_detector.py` |
+| 18   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/errata.md`            | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/errata.md`            |
+
+
+### A2. `app-studio-dataset-etl-gen-demo/references/vertical_detector.py` (5 broken refs)
+
+Lines 38-42 contain path constants for vertical pack files:
+
+
+| Line | Current (broken)                                                                                  | Replace with                                                                        |
+| ---- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 38   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/manufacturing.md`      | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/manufacturing.md`      |
+| 39   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/retail-ecommerce.md`   | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/retail-ecommerce.md`   |
+| 40   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/healthcare.md`         | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/healthcare.md`         |
+| 41   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/logistics.md`          | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/logistics.md`          |
+| 42   | `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/financial-services.md` | `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/financial-services.md` |
+
+
+### A3. `appdb-collection-create/SKILL.md` (2 broken refs)
+
+
+| Line | Current (broken)                    | Replace with                      |
+| ---- | ----------------------------------- | --------------------------------- |
+| 19   | `skills/custom-apps/appdb/SKILL.md` | `~/.agents/skills/appdb/SKILL.md` |
+| 88   | `skills/custom-apps/appdb/SKILL.md` | `~/.agents/skills/appdb/SKILL.md` |
+
+
+### A4. `code-engine/SKILL.md` (2 broken refs)
+
+
+| Line | Current (broken)                         | Replace with                                   |
+| ---- | ---------------------------------------- | ---------------------------------------------- |
+| 13   | `skills/cli/code-engine-create/SKILL.md` | `~/.agents/skills/code-engine-create/SKILL.md` |
+| 14   | `skills/cli/code-engine-update/SKILL.md` | `~/.agents/skills/code-engine-update/SKILL.md` |
+
+
+### A5. `code-engine-create/SKILL.md` (1 broken ref)
+
+
+| Line | Current (broken)                          | Replace with                            |
+| ---- | ----------------------------------------- | --------------------------------------- |
+| 19   | `skills/custom-apps/code-engine/SKILL.md` | `~/.agents/skills/code-engine/SKILL.md` |
+
+
+### A6. `code-engine-update/SKILL.md` (1 broken ref)
+
+
+| Line | Current (broken)                          | Replace with                            |
+| ---- | ----------------------------------------- | --------------------------------------- |
+| 19   | `skills/custom-apps/code-engine/SKILL.md` | `~/.agents/skills/code-engine/SKILL.md` |
+
+
+### A7. `manifest/SKILL.md` (2 broken refs)
+
+
+| Line | Current (broken)                         | Replace with                                   |
+| ---- | ---------------------------------------- | ---------------------------------------------- |
+| 14   | `skills/cli/code-engine-create/SKILL.md` | `~/.agents/skills/code-engine-create/SKILL.md` |
+| 15   | `skills/cli/code-engine-update/SKILL.md` | `~/.agents/skills/code-engine-update/SKILL.md` |
+
+
+### A8. `publish/SKILL.md` (2 broken refs)
+
+
+| Line | Current (broken)                         | Replace with                                   |
+| ---- | ---------------------------------------- | ---------------------------------------------- |
+| 40   | `skills/cli/code-engine-create/SKILL.md` | `~/.agents/skills/code-engine-create/SKILL.md` |
+| 41   | `skills/cli/code-engine-update/SKILL.md` | `~/.agents/skills/code-engine-update/SKILL.md` |
+
+
+### A9. Backtick-style skill refs (correct format, just verify)
+
+These use the format ``skill-name/SKILL.md`` which is ambiguous but works because the flat name matches. Found in:
+
+- `advanced-app-studio/SKILL.md` — references `card-creation/SKILL.md` (5 occurrences)
+- `app-studio/SKILL.md` — references `card-creation/SKILL.md` (5 occurrences)
+- `basic-app-build/SKILL.md` — references `app-studio/SKILL.md`, `card-creation/SKILL.md`, `app-studio-pro-code/SKILL.md`
+- `basic-app-studio/SKILL.md` — references `card-creation/SKILL.md` (2 occurrences)
+
+**Action:** These are fine as-is (relative name matches flat layout). No changes needed.
+
+---
+
+## 3. Part B — Add two-CLI boundary rule
+
+### File: `~/.claude/rules/core-custom-apps-rule.md`
+
+**Add the following section BEFORE the existing "CLI skills are optional" section (before line 24).** This is the single highest-impact change — it prevents the model from ever using `domo` for API operations. REMOVE THE CLI SKILLS ARE OPTIONAL. MAKE IT REQUIRED. TELL THE USER THEY NEED THE COMMUNITY CLI FOR THESE SKILLS TO WORK
+
+```markdown
+## Two CLIs — know which to use
+- **`domo` (official Domo CLI, `@domoinc/ryuu`)**: ONLY for `domo login`, `domo dev`, `domo publish`. It has NO dataset, card, app-studio, dataflow, or API commands.
+- **`community-domo-cli`**: ALL Domo Product API operations — datasets, app-studio, cards, dataflows, appdb, code-engine, filesets, workflows, pages, beast-modes, variables, domoapps, files, users, pdp.
+- If you need to fetch a dataset schema, create a card, list dataflows, or call any Domo API from the command line, the command ALWAYS starts with `community-domo-cli`, NEVER `domo`.
+- Auth: run `domo login` once (creates ryuu session), then all `community-domo-cli` commands reuse that session via `DOMO_INSTANCE` and `DOMO_AUTH_MODE=ryuu-session` env vars.
+```
+
+### Also update the existing "CLI skills are optional" section
+
+Change line 26 from:
+
+```
+- **Before using any `cli/` skill**, read `skills/cli/community-cli-howto/SKILL.md` first...
+```
+
+To:
+
+```
+- **Before using any CLI skill**, read `~/.agents/skills/community-cli-howto/SKILL.md` first for install, auth setup, supported commands, and troubleshooting.
+```
+
+---
+
+## 4. Part C — Update skill routing table
+
+### File: `~/.claude/rules/core-custom-apps-rule.md`
+
+Replace lines 43-81 (the entire "Skill routing" section) with flat paths. Also update lines 30-32 ("App Studio vs custom apps") which reference nested category dirs.
+
+**Replace lines 30-32 with:**
+
+```markdown
+## App Studio vs custom apps
+- **Custom app skills** (`dataset-query`, `appdb`, `toolkit`, `manifest`, `publish`, etc.) — code that runs *inside* a Domo custom app card.
+- **App Studio skills** (`basic-app-studio`, `advanced-app-studio`, `card-creation`, `beast-mode-creation`, `variable-creation`, `app-studio-pro-code`) — building and operating *App Studio* apps. Start with `basic-app-studio` for copy-paste CLI operations; use `advanced-app-studio` for the full layout/theme/reference material.
+```
+
+**Replace lines 43-81 with:**
+
+```markdown
+## Skill routing
+- New app build playbook -> `~/.agents/skills/basic-custom-app-build/SKILL.md`
+- App Studio + dataset/ETL vertical demo -> `~/.agents/skills/app-studio-dataset-etl-gen-demo/SKILL.md`
+- Dataset querying -> `~/.agents/skills/dataset-query/SKILL.md`
+- Data API overview -> `~/.agents/skills/data-api/SKILL.md`
+- domo.js usage -> `~/.agents/skills/domo-js/SKILL.md`
+- Toolkit usage -> `~/.agents/skills/toolkit/SKILL.md`
+- AppDB -> `~/.agents/skills/appdb/SKILL.md`
+- Community CLI howto (start here for any CLI skill) -> `~/.agents/skills/community-cli-howto/SKILL.md`
+- AppDB collection create (datastore + collection lifecycle) -> `~/.agents/skills/appdb-collection-create/SKILL.md`
+- AI services -> `~/.agents/skills/ai-service-layer/SKILL.md`
+- Code Engine -> `~/.agents/skills/code-engine/SKILL.md`
+- Code Engine package create -> `~/.agents/skills/code-engine-create/SKILL.md`
+- Code Engine package update -> `~/.agents/skills/code-engine-update/SKILL.md`
+- Workflows -> `~/.agents/skills/workflow/SKILL.md`
+- SQL queries -> `~/.agents/skills/sql-query/SKILL.md`
+- Manifest wiring -> `~/.agents/skills/manifest/SKILL.md`
+- Build/publish -> `~/.agents/skills/publish/SKILL.md`
+- DA CLI -> `~/.agents/skills/da-cli/SKILL.md`
+- Performance -> `~/.agents/skills/performance/SKILL.md`
+- Filesets API -> `~/.agents/skills/fileset-api/SKILL.md`
+- Filesets CLI -> `~/.agents/skills/fileset-cli/SKILL.md`
+- Migration from Lovable/v0 -> `~/.agents/skills/migrate-lovable/SKILL.md`
+- Migration from Google AI Studio -> `~/.agents/skills/migrate-googleai/SKILL.md`
+- App Studio (CLI operations only) -> `~/.agents/skills/basic-app-studio/SKILL.md`
+- App Studio (full CLI + reference) -> `~/.agents/skills/advanced-app-studio/SKILL.md`
+- App Studio pro-code embedded custom apps -> `~/.agents/skills/app-studio-pro-code/SKILL.md`
+- App Studio walkthrough video capture (Playwright) -> `~/.agents/skills/app-studio-demo-capture/SKILL.md`
+- Native KPI/card CRUD (Product API) -> `~/.agents/skills/card-creation/SKILL.md`
+- Beast modes -> `~/.agents/skills/beast-mode-creation/SKILL.md`
+- Card variables / controls -> `~/.agents/skills/variable-creation/SKILL.md`
+- Connector IDE -> `~/.agents/skills/connector-dev/SKILL.md`
+- Programmatic embed filters / dataset switching -> `~/.agents/skills/programmatic-filters/SKILL.md`
+- JS API filters -> `~/.agents/skills/jsapi-filters/SKILL.md`
+- Edit embed / Identity Broker -> `~/.agents/skills/edit-embed/SKILL.md`
+- Embed portal (full external-user portal) -> `~/.agents/skills/embed-portal/SKILL.md`
+- HTML slide deck to PDF -> `~/.agents/skills/html-deck/SKILL.md`
+- Default app theme -> `~/.agents/skills/domo-app-theme/SKILL.md`
+- Magic ETL (API-first / mixed) -> `~/.agents/skills/magic-etl/SKILL.md`
+- Magic ETL (community-domo-cli dataflows) -> `~/.agents/skills/magic-etl-cli/SKILL.md`
+- Sample data generation + upload -> `~/.agents/skills/domo-data-generator/SKILL.md`
+- Full end-to-end demo stack -> `~/.agents/skills/full-domo-stack/SKILL.md`
+- Workspaces admin -> `~/.agents/skills/workspaces/SKILL.md`
+```
+
+---
+
+## 5. Part D — Remove nested duplicate directories
+
+After all cross-references are updated to flat paths, the nested directories under `~/.agents/skills/` are dead weight that can cause the model to read stale content. Delete these entire directories:
+
+```
+~/.agents/skills/apps/                        (contains: ai-service-layer, appdb, code-engine, da-cli, data-api, dataset-query, domo-js, manifest, migrate-googleai, migrate-lovable, performance, publish, sql-query, toolkit, workflow)
+~/.agents/skills/cli/                         (contains: appdb-collection-create, code-engine-create, code-engine-update, community-cli-howto)
+~/.agents/skills/visualization/               (contains: app-studio, app-studio-pro-code, beast-mode-creation, card-creation, variable-creation)
+~/.agents/skills/themes/                      (contains: domo-app-theme)
+~/.agents/skills/connectors/                  (contains: connector-dev, data-upload-java-cli, json-no-code-connector)
+~/.agents/skills/domo-everywhere/             (contains: edit-embed, embed-portal, jsapi-filters, programmatic-filters)
+~/.agents/skills/documents/                   (contains: html-deck)
+~/.agents/skills/datagen/                     (contains: domo-data-generator)
+~/.agents/skills/orchestrator-skills/         (contains: basic-app-build, basic-app-build-w-video, initial-build)
+~/.agents/skills/administration/              (contains: workspaces)
+~/.agents/skills/transformation/              (contains: magic-etl)
+```
+
+**IMPORTANT:** Before deleting, verify each flat copy exists and is the newer/correct version. For pairs marked DIFFERENT in the audit, the flat copy should be kept. Here's the full list of duplicate pairs and their status:
+
+
+| Skill                   | Flat hash | Nested hash | Status                    |
+| ----------------------- | --------- | ----------- | ------------------------- |
+| ai-service-layer        | f59acff9  | 2cce500f    | DIFFERENT — keep flat     |
+| app-studio              | 3bdd4646  | f68ed1f4    | DIFFERENT — keep flat     |
+| app-studio-pro-code     | d1684c24  | b11b69a7    | DIFFERENT — keep flat     |
+| appdb                   | 8432cece  | baa23a96    | DIFFERENT — keep flat     |
+| appdb-collection-create | fbb1757f  | a2c14006    | DIFFERENT — keep flat     |
+| basic-app-build         | 00050c39  | 233db94f    | DIFFERENT — keep flat     |
+| basic-app-build-w-video | 1e54e0db  | 2c20e7f2    | DIFFERENT — keep flat     |
+| beast-mode-creation     | 9613ad81  | f8cf40e4    | DIFFERENT — keep flat     |
+| card-creation           | 5561ec47  | 21131aef    | DIFFERENT — keep flat     |
+| code-engine             | 67820338  | a20e091d    | DIFFERENT — keep flat     |
+| code-engine-create      | c0f8f816  | 71437d8a    | DIFFERENT — keep flat     |
+| code-engine-update      | 29bd489a  | 034c6ca7    | DIFFERENT — keep flat     |
+| community-cli-howto     | d441d2bb  | 5d3be572    | DIFFERENT — keep flat     |
+| connector-dev           | c539f1fe  | c539f1fe    | IDENTICAL — delete nested |
+| da-cli                  | 456a45bd  | 456a45bd    | IDENTICAL — delete nested |
+| data-api                | 6ef545c2  | 61a6bac4    | DIFFERENT — keep flat     |
+| data-upload-java-cli    | 89fc097f  | a87600c3    | DIFFERENT — keep flat     |
+| dataset-query           | dfd2e251  | dfd2e251    | IDENTICAL — delete nested |
+| domo-app-theme          | 34e25b29  | 58f79b3f    | DIFFERENT — keep flat     |
+| domo-data-generator     | f73ba8b3  | df890049    | DIFFERENT — keep flat     |
+| domo-js                 | b1e7dae9  | 99acfa00    | DIFFERENT — keep flat     |
+| edit-embed              | 83f39ba7  | 83f39ba7    | IDENTICAL — delete nested |
+| embed-portal            | 72ab7a8b  | 63187e64    | DIFFERENT — keep flat     |
+| html-deck               | d0c07266  | 2ea6d092    | DIFFERENT — keep flat     |
+| initial-build           | d7e84da4  | d7e84da4    | IDENTICAL — delete nested |
+| jsapi-filters           | 3f0a1115  | 3f0a1115    | IDENTICAL — delete nested |
+| json-no-code-connector  | 8f332003  | 956ab322    | DIFFERENT — keep flat     |
+| magic-etl               | 0682ee6e  | 0682ee6e    | IDENTICAL — delete nested |
+| manifest                | c8785dce  | 195497a3    | DIFFERENT — keep flat     |
+| migrate-googleai        | 4e8258f2  | 4e8258f2    | IDENTICAL — delete nested |
+| migrate-lovable         | 0b5010b4  | 0b5010b4    | IDENTICAL — delete nested |
+| performance             | 529892fa  | 529892fa    | IDENTICAL — delete nested |
+| programmatic-filters    | 7eccd538  | 7eccd538    | IDENTICAL — delete nested |
+| publish                 | c59c8c60  | c59c8c60    | IDENTICAL — delete nested |
+| sql-query               | bd0dc2db  | bd0dc2db    | IDENTICAL — delete nested |
+| toolkit                 | 66f5c0ea  | 66f5c0ea    | IDENTICAL — delete nested |
+| variable-creation       | cc24bba2  | 9ccae065    | DIFFERENT — keep flat     |
+| workflow                | 88254a9a  | 6db3ca82    | DIFFERENT — keep flat     |
+| workspaces              | cb567d38  | cdbd89d3    | DIFFERENT — keep flat     |
+
+
+---
+
+## 6. Part E — Content fixes from manufacturing demo build
+
+These are bugs and gaps discovered during a real end-to-end demo build on 2026-04-12. Each fix is specific to one skill.
+
+### E1. `magic-etl-cli/SKILL.md` — Document `PublishToVault` output action (CRITICAL)
+
+**Problem:** The skill documents input actions (`LoadFromVault`), transforms (`MergeJoin`, `GroupBy`, etc.), but never documents the output action type. Without this, no programmatically created dataflow can produce output. The model guessed `SaveToVault` which failed with `DP-0069: Illegal action type`.
+
+**Fix:** Add a `PublishToVault (Output Node)` section with the full JSON structure:
+
+```json
+{
+  "type": "PublishToVault",
+  "id": "PublishToVault-my-output",
+  "name": "Output Dataset Name",
+  "dependsOn": ["last-action-id"],
+  "settings": {"preferredDatabaseEntityType": "DYNAMIC_TABLE"},
+  "inputs": ["last-action-id"],
+  "dataSource": {
+    "guid": null,
+    "type": "DataFlow",
+    "name": "Output Dataset Name",
+    "description": "",
+    "cloudId": null
+  },
+  "versionChainType": "REPLACE",
+  "schemaSource": "DATAFLOW",
+  "partitioned": false,
+  "tables": [{}]
+}
+```
+
+Also add a valid action type list at the top of the "Action Types" section:
+
+```
+Valid types: LoadFromVault, PublishToVault, MergeJoin, GroupBy,
+WindowAction, Filter, ExpressionEvaluator, SQL
+
+NOT valid (will fail with DP-0069): SaveToVault, SelectValues, RenameColumns
+```
+
+### E2. `magic-etl-cli/SKILL.md` — Document `SelectValues` is invalid
+
+**Problem:** `SelectValues` was guessed as an action type and failed. The skill doesn't provide a definitive list of valid vs invalid types.
+
+**Fix:** Covered by the valid/invalid list in E1 above.
+
+### E3. `domo-data-generator/SKILL.md` — Add `weighted_choice` YAML example
+
+**Problem:** The skill lists `weighted_choice` as a generator option but never shows the correct YAML format. The model used a list-of-objects format that failed.
+
+**Fix:** Add a concrete example in the Generator Column Options table or in a subsection:
+
+```yaml
+generator: weighted_choice
+choices:
+  "Tier 1": 0.40
+  "Tier 2": 0.35
+  "Tier 3": 0.25
+```
+
+### E4. `domo-data-generator/SKILL.md` — Entity pool requirement note
+
+**Problem:** Running `datagen generate` before `datagen pool regenerate` fails even if the schema doesn't use `entity_ref` generators.
+
+**Fix:** Add a note in the `generate` command section: "Requires entity pool. Run `datagen pool regenerate` first if not already done, even if your schema doesn't use `entity_ref` generators."
+
+### E5. `domo-data-generator/SKILL.md` — Clarify auth model vs community CLI
+
+**Problem:** This skill lists `DOMO_CLIENT_ID`, `DOMO_CLIENT_SECRET`, and `DOMO_DEVELOPER_TOKEN` as required env vars. The community CLI has deprecated token auth. When skills are chained, it's confusing which auth model is in play.
+
+**Fix:** Add a note: "This tool uses the Domo public API with OAuth credentials for dataset upload — it does NOT use `community-domo-cli` or the ryuu session. The `DOMO_DEVELOPER_TOKEN` is used by the datagen tool's own HTTP calls, not by the community CLI."
+
+### E6. `community-cli-howto/SKILL.md` — Note token auth is deprecated
+
+**Problem:** The skill doesn't mention that `auth_mode: "token"` is no longer supported by the community CLI.
+
+**Fix:** Add to the Auth setup section: "**Token auth (`auth_mode: token`) is deprecated.** The only supported auth mode is `ryuu-session`. If you see `Token auth mode is no longer supported`, re-run `domo login -i <instance>` and set `DOMO_AUTH_MODE=ryuu-session`."
+
+### E7. Theme DESIGN.md files — Document UI import vs API format difference
+
+**Problem:** The "Importable JSON" in theme DESIGN.md files uses a simplified format (`index`, string weights, `"22px"` sizes) intended for the App Studio UI import dialog. The programmatic API expects a different format (`id` like `"c1"`/`"f1"`, numeric weights, bare integer sizes, nested value objects). Every programmatic theme application hits this mismatch.
+
+**Affects:** All theme files under `~/.agents/skills/domo-app-theme/references/themes/*.DESIGN.md`
+
+**Fix for each DESIGN.md:** Add a warning block above or below Section 10 (Importable JSON):
+
+```markdown
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no "px"); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `"NONE"`, `"SMALL"`, `"MEDIUM"`, `"LARGE"` (not boolean); `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+```
+
+### E8. `advanced-app-studio/SKILL.md` — Add API-compatible theme format notes
+
+**Problem:** The Theme Management section doesn't explicitly document the color/font/card object formats the API expects.
+
+**Fix:** In the Theme Management section, add:
+
+```markdown
+### API Color Object Format
+{"id": "c1", "value": {"value": "#141008", "type": "RGB_HEX"}, "tags": ["THEME", "PRIMARY", "TINTED_GRAY"]}
+
+### API Font Object Format
+{"id": "f1", "family": "Sans", "weight": 600, "size": 22, "style": "Regular"}
+
+### API Card Style Object Format
+{"id": "ca1", "borderRadius": 0, "borderWidth": 0, "dropShadow": "NONE", "padding": {"left": 0, "right": 0, "top": 0, "bottom": 0}}
+
+### Valid dropShadow values
+"NONE", "SMALL", "MEDIUM", "LARGE"
+```
+
+### E9. `app-studio-dataset-etl-gen-demo/SKILL.md` — Add explicit CLI guidance at step 0
+
+**Problem:** Step 0 says "Fetch schema/columns for the provided datasets first" but doesn't specify which CLI to use.
+
+**Fix:** Change step 0 text to:
+
+```markdown
+0. **If user provides dataset IDs, detect vertical before pack selection**:
+   - Fetch schema/columns using `community-domo-cli datasets schema <dataset_id>` for each provided dataset.
+   - Match columns to a reference vertical using this map:
+```
+
+### E10. `app-studio-dataset-etl-gen-demo/SKILL.md` — Nav icons manual step
+
+**Problem:** Step 10 says "Navigation: LEFT orientation, reorder pages, HOME first, showTitle false" as a build step without noting icons require manual UI work.
+
+**Fix:** The current skill text already has "INFORM USER icons must be set manually in App Studio UI" — verify this is present. If missing, add: "Icons must be set manually in the App Studio UI after the programmatic build (hover page name in left nav -> click icon to change)."
+
+---
+
+## 7. Verification checklist
+
+After all changes are applied, run this verification:
+
+```bash
+# 1. No nested path references remain in flat skills
+grep -r "skills/\(cli\|custom-apps\|app-studio\|themes\|demo-skills\|(demo-skills)\|transformation\|visualization\|connectors\|domo-everywhere\|documents\|datagen\|orchestrator-skills\|administration\|apps\)/" ~/.agents/skills/*/SKILL.md ~/.agents/skills/*/references/*.py ~/.agents/skills/*/references/*.md 2>/dev/null
+
+# 2. No nested duplicate directories remain
+ls -d ~/.agents/skills/apps/ ~/.agents/skills/cli/ ~/.agents/skills/visualization/ ~/.agents/skills/themes/ ~/.agents/skills/connectors/ ~/.agents/skills/domo-everywhere/ ~/.agents/skills/documents/ ~/.agents/skills/datagen/ ~/.agents/skills/orchestrator-skills/ ~/.agents/skills/administration/ ~/.agents/skills/transformation/ 2>/dev/null
+# Expected: all "No such file or directory"
+
+# 3. All flat skills still have SKILL.md
+for d in ~/.agents/skills/*/; do
+  [ -f "$d/SKILL.md" ] || echo "MISSING: $d/SKILL.md"
+done
+
+# 4. Core rule routing table paths all resolve
+grep '~/.agents/skills/' ~/.claude/rules/core-custom-apps-rule.md | sed 's/.*`\(.*\)`.*/\1/' | while read p; do
+  eval test -f "$p" || echo "BROKEN: $p"
+done
+
+# 5. "domo datasets" or "domo appdb" etc. never appear as CLI commands in any skill
+grep -rn '\bdomo \(datasets\?\|appdb\|app-studio\|cards\|pages\|filesets\?\|code-engine\|workflows\?\|dataflows\?\|beast-mode\|variables\?\|users\?\|pdp\|domoapps\|files\) ' ~/.agents/skills/*/SKILL.md 2>/dev/null
+# Expected: no matches (only "community-domo-cli" should precede these subcommands)
+# Note: "domo.get()", "domo.post()", "domo publish", "domo login", "domo dev" are fine — those are JS SDK or ryuu CLI
+```
+
+---
+
+## Summary of scope
+
+
+| Part | Files affected                          | Changes                          |
+| ---- | --------------------------------------- | -------------------------------- |
+| A    | 8 skill files                           | 29 path fixes (find-and-replace) |
+| B    | 1 rule file                             | Add ~6 lines                     |
+| C    | 1 rule file                             | Rewrite ~40 lines                |
+| D    | 11 nested dirs                          | Delete after verification        |
+| E    | 6 skill files + N theme DESIGN.md files | Content additions                |
+
+
+**Execution order:** B and C first (core rule), then A (cross-refs), then E (content), then D (cleanup) last.

--- a/rules/core-custom-apps-rule.md
+++ b/rules/core-custom-apps-rule.md
@@ -21,15 +21,18 @@ alwaysApply: true
 - Use relative asset base for Domo hosting (`base: './'`).
 - Prefer `HashRouter` unless rewrite behavior is known and intentional.
 
-## CLI skills are optional
-- All skills under `skills/cli/` use the **community-domo-cli** (not the official Domo CLI `@domoinc/ryuu`). They automate tasks like creating AppDB collections, Code Engine packages, or fetching dataset/resource IDs.
-- **Before using any `cli/` skill**, read `skills/cli/community-cli-howto/SKILL.md` first for install, auth setup, supported commands, and troubleshooting.
-- These skills are **strictly optional helpers**. If the community CLI is not installed or the user does not want to use it, **skip those skills gracefully** and fall back to asking the user to provide the needed IDs/resources manually or perform the step in the Domo UI.
-- Other skills (e.g. `code-engine`, `appdb`) may suggest using a `cli/` skill first. That suggestion is a convenience, not a requirement — it must **never block the build**.
+## Two CLIs — know which to use
+- **`domo` (official Domo CLI, `@domoinc/ryuu`)**: only for `domo login`, `domo dev`, and `domo publish`.
+- **`community-domo-cli`**: required for Domo Product API operations (datasets, app-studio, cards, dataflows, appdb, code-engine, filesets, workflows, pages, beast-modes, variables, domoapps, files, users, pdp).
+- **`python -m datagen` (`domo_data_generator`)**: separate tool for sample-data generation and dataset create/upload flows that call Domo public APIs directly. This is the current path for datagen dataset provisioning until equivalent coverage lands in `community-domo-cli`.
+- If you need schema fetches, card create/update, dataflow commands, or Product API CLI calls, the command must start with `community-domo-cli` (never `domo`).
+- Auth flow: run `domo login` once, then run `community-domo-cli` using `DOMO_INSTANCE` plus `DOMO_AUTH_MODE=ryuu-session`.
+- Datagen auth is different from ryuu session: create a local `.env` with `DOMO_CLIENT_ID` and `DOMO_CLIENT_SECRET` (and other datagen vars) before running `python -m datagen ...`.
+- **Before using any CLI skill**, read `~/.agents/skills/community-cli-howto/SKILL.md` first for install, auth setup, supported commands, and troubleshooting.
 
 ## App Studio vs custom apps
-- **`skills/custom-apps/`** — code that runs *inside* a Domo custom app card (data, AppDB, toolkit, manifest, publish).
-- **`skills/app-studio/`** — building and operating *App Studio* apps (pages, layouts, native KPI cards, variables, beast modes, pro-code iframes). Start with `basic-app-studio` for copy-paste CLI operations; use `advanced-app-studio` for the full layout/theme/reference material.
+- **Custom app skills** (`dataset-query`, `appdb`, `toolkit`, `manifest`, `publish`, etc.) — code that runs *inside* a Domo custom app card.
+- **App Studio skills** (`basic-app-studio`, `advanced-app-studio`, `card-creation`, `beast-mode-creation`, `variable-creation`, `app-studio-pro-code`) — building and operating *App Studio* apps. Start with `basic-app-studio` for copy-paste CLI operations; use `advanced-app-studio` for full layout/theme/reference material.
 
 ## API index
 - Data API
@@ -41,41 +44,45 @@ alwaysApply: true
 - Files / Filesets / Groups / User / Task Center
 
 ## Skill routing
-- New app build playbook -> `skills/(demo-skills)/basic-custom-app-build/SKILL.md`
-- App Studio + dataset/ETL vertical demo -> `skills/(demo-skills)/app-studio-dataset-etl-gen-demo/SKILL.md`
-- Dataset querying -> `skills/custom-apps/dataset-query/SKILL.md`
-- Data API overview -> `skills/custom-apps/data-api/SKILL.md`
-- domo.js usage -> `skills/custom-apps/domo-js/SKILL.md`
-- Toolkit usage -> `skills/custom-apps/toolkit/SKILL.md`
-- AppDB -> `skills/custom-apps/appdb/SKILL.md`
-- Community CLI howto (start here for any CLI skill) -> `skills/cli/community-cli-howto/SKILL.md`
-- AppDB collection create (datastore + collection lifecycle) -> `skills/cli/appdb-collection-create/SKILL.md`
-- AI services -> `skills/custom-apps/ai-service-layer/SKILL.md`
-- Code Engine -> `skills/custom-apps/code-engine/SKILL.md`
-- Code Engine package create -> `skills/cli/code-engine-create/SKILL.md`
-- Code Engine package update -> `skills/cli/code-engine-update/SKILL.md`
-- Workflows -> `skills/custom-apps/workflow/SKILL.md`
-- SQL queries -> `skills/custom-apps/sql-query/SKILL.md`
-- Manifest wiring -> `skills/custom-apps/manifest/SKILL.md`
-- Build/publish -> `skills/custom-apps/publish/SKILL.md`
-- DA CLI -> `skills/custom-apps/da-cli/SKILL.md`
-- Performance -> `skills/custom-apps/performance/SKILL.md`
-- Filesets API -> `skills/custom-apps/fileset-api/SKILL.md`
-- Migration from Lovable/v0 -> `skills/custom-apps/migrate-lovable/SKILL.md`
-- Migration from Google AI Studio -> `skills/custom-apps/migrate-googleai/SKILL.md`
-- App Studio (CLI operations only) -> `skills/app-studio/basic-app-studio/SKILL.md`
-- App Studio (full CLI + reference) -> `skills/app-studio/advanced-app-studio/SKILL.md`
-- App Studio pro-code embedded custom apps -> `skills/app-studio/app-studio-pro-code/SKILL.md`
-- App Studio walkthrough video capture (Playwright) -> `skills/app-studio/app-studio-demo-capture/SKILL.md`
-- Native KPI/card CRUD (Product API) -> `skills/app-studio/card-creation/SKILL.md`
-- Beast modes -> `skills/app-studio/beast-mode-creation/SKILL.md`
-- Card variables / controls -> `skills/app-studio/variable-creation/SKILL.md`
-- Connector IDE -> `skills/connectors/connector-dev/SKILL.md`
-- Programmatic embed filters / dataset switching -> `skills/domo-everywhere/programmatic-filters/SKILL.md`
-- JS API filters -> `skills/domo-everywhere/jsapi-filters/SKILL.md`
-- Edit embed / Identity Broker -> `skills/domo-everywhere/edit-embed/SKILL.md`
-- Embed portal (full external-user portal) -> `skills/domo-everywhere/embed-portal/SKILL.md`
-- HTML slide deck to PDF -> `skills/documents/html-deck/SKILL.md`
-- Default app theme -> `skills/themes/domo-app-theme/SKILL.md`
-- Magic ETL (API-first / mixed) -> `skills/transformation/magic-etl/SKILL.md`
-- Magic ETL (community-domo-cli dataflows) -> `skills/transformation/magic-etl-cli/SKILL.md`
+- New app build playbook -> `~/.agents/skills/basic-custom-app-build/SKILL.md`
+- App Studio + dataset/ETL vertical demo -> `~/.agents/skills/app-studio-dataset-etl-gen-demo/SKILL.md`
+- Dataset querying -> `~/.agents/skills/dataset-query/SKILL.md`
+- Data API overview -> `~/.agents/skills/data-api/SKILL.md`
+- domo.js usage -> `~/.agents/skills/domo-js/SKILL.md`
+- Toolkit usage -> `~/.agents/skills/toolkit/SKILL.md`
+- AppDB -> `~/.agents/skills/appdb/SKILL.md`
+- Community CLI howto (start here for any CLI skill) -> `~/.agents/skills/community-cli-howto/SKILL.md`
+- AppDB collection create (datastore + collection lifecycle) -> `~/.agents/skills/appdb-collection-create/SKILL.md`
+- AI services -> `~/.agents/skills/ai-service-layer/SKILL.md`
+- Code Engine -> `~/.agents/skills/code-engine/SKILL.md`
+- Code Engine package create -> `~/.agents/skills/code-engine-create/SKILL.md`
+- Code Engine package update -> `~/.agents/skills/code-engine-update/SKILL.md`
+- Workflows -> `~/.agents/skills/workflow/SKILL.md`
+- SQL queries -> `~/.agents/skills/sql-query/SKILL.md`
+- Manifest wiring -> `~/.agents/skills/manifest/SKILL.md`
+- Build/publish -> `~/.agents/skills/publish/SKILL.md`
+- DA CLI -> `~/.agents/skills/da-cli/SKILL.md`
+- Performance -> `~/.agents/skills/performance/SKILL.md`
+- Filesets API -> `~/.agents/skills/fileset-api/SKILL.md`
+- Filesets CLI -> `~/.agents/skills/fileset-cli/SKILL.md`
+- Migration from Lovable/v0 -> `~/.agents/skills/migrate-lovable/SKILL.md`
+- Migration from Google AI Studio -> `~/.agents/skills/migrate-googleai/SKILL.md`
+- App Studio (CLI operations only) -> `~/.agents/skills/basic-app-studio/SKILL.md`
+- App Studio (full CLI + reference) -> `~/.agents/skills/advanced-app-studio/SKILL.md`
+- App Studio pro-code embedded custom apps -> `~/.agents/skills/app-studio-pro-code/SKILL.md`
+- App Studio walkthrough video capture (Playwright) -> `~/.agents/skills/app-studio-demo-capture/SKILL.md`
+- Native KPI/card CRUD (Product API) -> `~/.agents/skills/card-creation/SKILL.md`
+- Beast modes -> `~/.agents/skills/beast-mode-creation/SKILL.md`
+- Card variables / controls -> `~/.agents/skills/variable-creation/SKILL.md`
+- Connector IDE -> `~/.agents/skills/connector-dev/SKILL.md`
+- Programmatic embed filters / dataset switching -> `~/.agents/skills/programmatic-filters/SKILL.md`
+- JS API filters -> `~/.agents/skills/jsapi-filters/SKILL.md`
+- Edit embed / Identity Broker -> `~/.agents/skills/edit-embed/SKILL.md`
+- Embed portal (full external-user portal) -> `~/.agents/skills/embed-portal/SKILL.md`
+- HTML slide deck to PDF -> `~/.agents/skills/html-deck/SKILL.md`
+- Default app theme -> `~/.agents/skills/domo-app-theme/SKILL.md`
+- Magic ETL (API-first / mixed) -> `~/.agents/skills/magic-etl/SKILL.md`
+- Magic ETL (community-domo-cli dataflows) -> `~/.agents/skills/magic-etl-cli/SKILL.md`
+- Sample data generation + upload -> `~/.agents/skills/domo-data-generator/SKILL.md`
+- Full end-to-end demo stack -> `~/.agents/skills/full-domo-stack/SKILL.md`
+- Workspaces admin -> `~/.agents/skills/workspaces/SKILL.md`

--- a/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/SKILL.md
+++ b/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/SKILL.md
@@ -9,13 +9,13 @@ description: Vertical App Studio micro-demo with optional dataset creation (domo
 
 Read these helper scripts (they encode the API patterns used by this demo flow):
 
-1. `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/cli_helpers.py` — API wrappers
-2. `~/.agents/skills/app-studio/advanced-app-studio/references/card_templates.py` — card body builders
-3. `~/.agents/skills/app-studio/advanced-app-studio/references/layout_assembler.py` — layout composition
-4. `~/.agents/skills/themes/domo-app-theme/references/theme_transform.py` — theme format bridge
-5. `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/theme_loader.py` — pick theme (reads compact index at runtime)
-6. `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/vertical_detector.py` — auto-detect vertical
-7. `~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/errata.md` — API gotchas
+1. `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/cli_helpers.py` — API wrappers
+2. `~/.agents/skills/advanced-app-studio/references/card_templates.py` — card body builders
+3. `~/.agents/skills/advanced-app-studio/references/layout_assembler.py` — layout composition
+4. `~/.agents/skills/domo-app-theme/references/theme_transform.py` — theme format bridge
+5. `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/theme_loader.py` — pick theme (reads compact index at runtime)
+6. `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/vertical_detector.py` — auto-detect vertical
+7. `~/.agents/skills/app-studio-dataset-etl-gen-demo/references/errata.md` — API gotchas
 
 Do NOT read full `advanced-app-studio/SKILL.md` or theme DESIGN.md files unless a helper script path does not cover the operation you need.
 
@@ -41,7 +41,7 @@ Needs dataset id's to power cards. Sources:
 ## Procedure
 
 0. **If user provides dataset IDs, detect vertical before pack selection**:
-   - Fetch schema/columns for the provided datasets first.
+   - Fetch schema/columns using `community-domo-cli datasets schema <dataset_id>` for each provided dataset.
    - Match columns to a reference vertical using this map:
 
 | Key columns | Vertical |

--- a/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/vertical_detector.py
+++ b/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/vertical_detector.py
@@ -35,11 +35,11 @@ VERTICAL_SIGNATURES = {
 
 
 REFERENCE_PACKS = {
-    "manufacturing": "~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/manufacturing.md",
-    "retail-ecommerce": "~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/retail-ecommerce.md",
-    "healthcare": "~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/healthcare.md",
-    "logistics": "~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/logistics.md",
-    "financial-services": "~/.agents/skills/(demo-skills)/app-studio-dataset-etl-gen-demo/references/financial-services.md",
+    "manufacturing": "~/.agents/skills/app-studio-dataset-etl-gen-demo/references/manufacturing.md",
+    "retail-ecommerce": "~/.agents/skills/app-studio-dataset-etl-gen-demo/references/retail-ecommerce.md",
+    "healthcare": "~/.agents/skills/app-studio-dataset-etl-gen-demo/references/healthcare.md",
+    "logistics": "~/.agents/skills/app-studio-dataset-etl-gen-demo/references/logistics.md",
+    "financial-services": "~/.agents/skills/app-studio-dataset-etl-gen-demo/references/financial-services.md",
 }
 
 

--- a/skills/app-studio/advanced-app-studio/SKILL.md
+++ b/skills/app-studio/advanced-app-studio/SKILL.md
@@ -694,14 +694,14 @@ Cards should use **zero border-radius, zero border weight, zero padding, no drop
 card['backgroundColor'] = {'value': 'c56', 'type': 'COLOR_REFERENCE'}  # white
 card['borderWidth'] = 0
 card['borderRadius'] = 0
-card['dropShadow'] = 'NONE'
+card['dropShadow'] = None
 card['padding'] = {'left': 0, 'right': 0, 'top': 0, 'bottom': 0}
 
 # ca8 — fully transparent (banners, images)
 card['backgroundColor'] = {'value': 'c56', 'opacity': '00', 'type': 'COLOR_REFERENCE'}
 card['borderWidth'] = 0
 card['borderRadius'] = 0
-card['dropShadow'] = 'NONE'
+card['dropShadow'] = None
 ```
 
 ### Page Background: Ultra-Light Gray
@@ -1809,12 +1809,30 @@ for pill in theme.get('pills', []):
 
 All card styles MUST follow this reference configuration. Zero border-radius, zero border weight, zero padding, no drop shadow, no content spacing:
 
+### API Theme Object Formats
+
+Use API-compatible object shapes when patching theme values programmatically:
+
+```json
+{"id": "c1", "value": {"value": "#141008", "type": "RGB_HEX"}, "tags": ["THEME", "PRIMARY", "TINTED_GRAY"]}
+```
+
+```json
+{"id": "f1", "family": "Sans", "weight": 600, "size": 22, "style": "Regular"}
+```
+
+```json
+{"id": "ca1", "borderRadius": 0, "borderWidth": 0, "dropShadow": null, "padding": {"left": 0, "right": 0, "top": 0, "bottom": 0}}
+```
+
+Valid `dropShadow` values in App Studio API payloads: `null`, `"FLOATING"`, `"STANDARD"`.
+
 ```python
 # ca1-ca7 — clean surface, zero chrome (default for all content cards)
 for card in theme.get('cards', []):
     card['borderRadius'] = 0
     card['borderWidth'] = 0
-    card['dropShadow'] = 'NONE'
+    card['dropShadow'] = None
     card['dropShadowColor'] = None
     card['padding'] = {'left': 0, 'right': 0, 'top': 0, 'bottom': 0}
     card['contentSpacing'] = None       # "Card content spacing: Nil"
@@ -1828,7 +1846,7 @@ Keep ca8 as fully transparent/borderless for banners and pro-code frames:
 card['backgroundColor'] = {'value': 'c56', 'opacity': '00', 'type': 'COLOR_REFERENCE'}
 card['borderWidth'] = 0
 card['borderRadius'] = 0
-card['dropShadow'] = 'NONE'
+card['dropShadow'] = None
 card['padding'] = {'left': 0, 'right': 0, 'top': 0, 'bottom': 0}
 ```
 
@@ -1839,7 +1857,7 @@ card['padding'] = {'left': 0, 'right': 0, 'top': 0, 'bottom': 0}
 | -------------------------- | ---------------- | --------------------------------------------- |
 | Rounded corners            | **0 px**         | `borderRadius: 0`                             |
 | Border weight              | **0 px**         | `borderWidth: 0`                              |
-| Drop shadow                | **None**         | `dropShadow: 'NONE'`                          |
+| Drop shadow                | **None**         | `dropShadow: null`                            |
 | Controls color             | **#2563BE**      | Theme color `c8` -> `#2563BE`                 |
 | Card inner padding         | **Custom, 0 px** | `padding: {left:0, right:0, top:0, bottom:0}` |
 | Card content spacing       | **Nil**          | `contentSpacing: None` (null)                 |

--- a/skills/cli/appdb-collection-create/SKILL.md
+++ b/skills/cli/appdb-collection-create/SKILL.md
@@ -16,7 +16,7 @@ This skill covers storage initialization lifecycle:
 - capture resulting identifiers
 - prepare follow-up manifest mapping and document-write usage
 
-For document CRUD operations after collection exists, use `skills/custom-apps/appdb/SKILL.md`.
+For document CRUD operations after collection exists, use `~/.agents/skills/appdb/SKILL.md`.
 
 ## Assumed CLI Behavior
 
@@ -85,4 +85,4 @@ After successful creation, ensure app manifest contains collection wiring expect
 - [ ] CLI collection-create path used first
 - [ ] Datastore+collection identifiers captured
 - [ ] Manifest collection mapping follow-up performed
-- [ ] Hand-off to document CRUD flow (`skills/custom-apps/appdb/SKILL.md`) is clear
+- [ ] Hand-off to document CRUD flow (`~/.agents/skills/appdb/SKILL.md`) is clear

--- a/skills/cli/code-engine-create/SKILL.md
+++ b/skills/cli/code-engine-create/SKILL.md
@@ -16,7 +16,7 @@ This skill covers lifecycle operations that are out of scope for app-runtime inv
 - infer and normalize function input/output datatypes
 - update app `manifest.json` `packagesMapping` entries after create
 
-For in-app function invocation patterns, use `skills/custom-apps/code-engine/SKILL.md`.
+For in-app function invocation patterns, use `~/.agents/skills/code-engine/SKILL.md`.
 
 ## Primary Execution Path
 

--- a/skills/cli/code-engine-update/SKILL.md
+++ b/skills/cli/code-engine-update/SKILL.md
@@ -16,7 +16,7 @@ This skill covers:
 - detect and handle mapping drift between package and app manifest
 - validate datatype contract stability
 
-For app-runtime invocation code, use `skills/custom-apps/code-engine/SKILL.md`.
+For app-runtime invocation code, use `~/.agents/skills/code-engine/SKILL.md`.
 
 ## Primary Execution Path
 

--- a/skills/cli/community-cli-howto/SKILL.md
+++ b/skills/cli/community-cli-howto/SKILL.md
@@ -44,6 +44,8 @@ export DOMO_AUTH_MODE=ryuu-session
 community-domo-cli datasets list
 ```
 
+> **Token auth is deprecated.** `auth_mode=token` is no longer supported by `community-domo-cli`. If you see "Token auth mode is no longer supported", run `domo login -i <instance>` again and keep `DOMO_AUTH_MODE=ryuu-session`.
+
 - CLI reads the login file from `~/.config/configstore/ryuu/<instance>.json`
 - It reuses refresh/session behavior from `domo login`
 

--- a/skills/custom-apps/code-engine/SKILL.md
+++ b/skills/custom-apps/code-engine/SKILL.md
@@ -10,8 +10,8 @@ In practice, prefer direct `domo.post('/domo/codeengine/v2/packages/{alias}', pa
 
 Package lifecycle operations are handled by CLI skills:
 
-- `skills/cli/code-engine-create/SKILL.md`
-- `skills/cli/code-engine-update/SKILL.md`
+- `~/.agents/skills/code-engine-create/SKILL.md`
+- `~/.agents/skills/code-engine-update/SKILL.md`
 
 Use this skill for runtime invocation patterns inside app code, not package create/update orchestration.
 

--- a/skills/custom-apps/manifest/SKILL.md
+++ b/skills/custom-apps/manifest/SKILL.md
@@ -11,8 +11,8 @@ The `manifest.json` file is critical - it declares all external resources your a
 
 For package create/update lifecycle details that feed `packagesMapping`, use:
 
-- `skills/cli/code-engine-create/SKILL.md`
-- `skills/cli/code-engine-update/SKILL.md`
+- `~/.agents/skills/code-engine-create/SKILL.md`
+- `~/.agents/skills/code-engine-update/SKILL.md`
 
 ## Basic structure
 ```json

--- a/skills/custom-apps/publish/SKILL.md
+++ b/skills/custom-apps/publish/SKILL.md
@@ -37,8 +37,8 @@ domo publish         # Publish to Domo
 
 If publish includes new/updated Code Engine packages, run package lifecycle steps first via:
 
-- `skills/cli/code-engine-create/SKILL.md`
-- `skills/cli/code-engine-update/SKILL.md`
+- `~/.agents/skills/code-engine-create/SKILL.md`
+- `~/.agents/skills/code-engine-update/SKILL.md`
 
 **Important - First publish:**
 - On first publish, Domo generates a new `id` for your app

--- a/skills/datagen/domo-data-generator/SKILL.md
+++ b/skills/datagen/domo-data-generator/SKILL.md
@@ -41,16 +41,31 @@ cp .env.example .env
 # Edit .env with your Domo credentials
 ```
 
+If `.env.example` is missing or you want a clean start, create `.env` in the working directory with:
+
+```bash
+cat > .env <<'EOF'
+DOMO_CLIENT_ID=your_client_id_here
+DOMO_CLIENT_SECRET=your_client_secret_here
+DOMO_API_HOST=api.domo.com
+DOMO_INSTANCE=your_instance_name
+DOMO_SET_CONNECTOR_TYPE=false
+EOF
+```
+
 ### Required Environment Variables
 
 | Variable | Purpose |
 |----------|---------|
 | `DOMO_CLIENT_ID` | OAuth client identifier |
 | `DOMO_CLIENT_SECRET` | OAuth client secret |
-| `DOMO_DEVELOPER_TOKEN` | Internal API auth token |
 | `DOMO_API_HOST` | API endpoint hostname |
 | `DOMO_INSTANCE` | Domo instance name |
 | `DOMO_SET_CONNECTOR_TYPE` | Enable connector icon customization (optional, default: false) |
+
+> **Auth boundary note:** `domo_data_generator` uses its own public-API/OAuth credential flow and does **not** run through `community-domo-cli` or ryuu session auth.
+>
+> **Current tooling boundary:** most Product API automation should use `community-domo-cli`, but datagen dataset create/upload in this skill currently depends on `python -m datagen` with `.env` OAuth credentials (`DOMO_CLIENT_ID` / `DOMO_CLIENT_SECRET`).
 
 ---
 
@@ -70,6 +85,8 @@ python -m datagen generate salesforce_opportunities  # Generate one dataset
 python -m datagen generate --all --seed 42          # Reproducible generation
 python -m datagen generate --all --dry-run          # Preview without writing
 ```
+
+Requires entity pool initialization first. Run `python -m datagen pool regenerate` before `generate` even if your schema has no explicit `entity_ref` columns.
 
 | Option | Description |
 |--------|-------------|
@@ -315,6 +332,16 @@ columns:
 | `format` | `derived_from_date` | Date format string |
 | `faker_method` | `faker` | Faker library method name |
 | `faker_args` | `faker` | Arguments for the Faker method |
+
+**`weighted_choice` YAML format:**
+
+```yaml
+generator: weighted_choice
+choices:
+  "Tier 1": 0.40
+  "Tier 2": 0.35
+  "Tier 3": 0.25
+```
 
 > **`compound` `refs` vs formatted random strings:** For values like `PO-12345`, prefer **`faker`** with **`bothify`** instead of abusing `compound` / `refs`:
 >

--- a/skills/themes/domo-app-theme/references/themes/arctic-frost.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/arctic-frost.DESIGN.md
@@ -282,6 +282,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/atompunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/atompunk.DESIGN.md
@@ -443,6 +443,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements all colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/bc-forest-dark.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/bc-forest-dark.DESIGN.md
@@ -267,6 +267,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 Paste into App Studio → Theme Editor → Import. After import, spot-check left nav links, tab labels, and table headers for contrast.

--- a/skills/themes/domo-app-theme/references/themes/bc-forest-light.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/bc-forest-light.DESIGN.md
@@ -152,6 +152,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 7. App Studio Theme JSON (Importable)
 
 The source theme JSON file is `Custom-Theme---BC-UX---Custom2.json`. Apply via the App Studio PUT endpoint using the full JSON payload. Key slot summary:

--- a/skills/themes/domo-app-theme/references/themes/biopunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/biopunk.DESIGN.md
@@ -440,6 +440,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/blueprint.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/blueprint.DESIGN.md
@@ -394,6 +394,13 @@ Mirror semantic names in `:root` for custom apps (`--surface` → `c2`, `--text-
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/blush-rose.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/blush-rose.DESIGN.md
@@ -263,6 +263,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/burgundy-editorial.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/burgundy-editorial.DESIGN.md
@@ -283,6 +283,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/ch-charcoal-dark.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/ch-charcoal-dark.DESIGN.md
@@ -288,6 +288,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/ch-charcoal-light.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/ch-charcoal-light.DESIGN.md
@@ -170,6 +170,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 The source theme JSON file is `Custom-Theme--CH-UX---Charcoal.json`. Apply via the App Studio PUT endpoint using the full JSON payload. Key slot summary:

--- a/skills/themes/domo-app-theme/references/themes/charcoal-ember-dark.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/charcoal-ember-dark.DESIGN.md
@@ -425,6 +425,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements all colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/copper-patina.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/copper-patina.DESIGN.md
@@ -266,6 +266,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/corporate-light.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/corporate-light.DESIGN.md
@@ -437,6 +437,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/cyberpunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/cyberpunk.DESIGN.md
@@ -443,6 +443,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/data-ink.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/data-ink.DESIGN.md
@@ -396,6 +396,13 @@ Mirror semantic names in `:root` for custom apps (`--surface` → `c2`, `--text-
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/dieselpunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/dieselpunk.DESIGN.md
@@ -439,6 +439,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements colors, fonts, card styles ( **6px** radius), navigation, tables, tabs, and forms for the Dieselpunk system.

--- a/skills/themes/domo-app-theme/references/themes/dreadpunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/dreadpunk.DESIGN.md
@@ -436,6 +436,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements all colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/dungeonpunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/dungeonpunk.DESIGN.md
@@ -435,6 +435,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the Dungeonpunk palette, **8px** card radius, fonts, navigation (**`c58` only** — no `c60`), tables, tabs, and forms.

--- a/skills/themes/domo-app-theme/references/themes/electric-teal.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/electric-teal.DESIGN.md
@@ -274,6 +274,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/emerald-dark.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/emerald-dark.DESIGN.md
@@ -430,6 +430,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements all colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/golden-hour.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/golden-hour.DESIGN.md
@@ -403,6 +403,13 @@ Mirror semantic names in `:root` for custom apps (`--surface` → `c2`, `--text-
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/indigo-velvet.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/indigo-velvet.DESIGN.md
@@ -278,6 +278,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/midnight-navy.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/midnight-navy.DESIGN.md
@@ -262,6 +262,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/moss-stone.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/moss-stone.DESIGN.md
@@ -281,6 +281,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/neon-magenta-dark.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/neon-magenta-dark.DESIGN.md
@@ -433,6 +433,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/ocean-kelp.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/ocean-kelp.DESIGN.md
@@ -409,6 +409,13 @@ Mirror semantic names in `:root` for custom apps (`--surface` → `c2`, `--text-
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/slate-granite.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/slate-granite.DESIGN.md
@@ -258,6 +258,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/solarpunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/solarpunk.DESIGN.md
@@ -450,6 +450,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the colors, fonts, card styles, navigation, and component settings defined in this document.

--- a/skills/themes/domo-app-theme/references/themes/steampunk.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/steampunk.DESIGN.md
@@ -429,6 +429,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 10. App Studio Theme JSON (Importable)
 
 The complete theme JSON below can be imported directly into Domo App Studio. It implements the Steampunk palette, **8px** card radius, fonts, navigation ( **`c58` / `c59` only — never `c60`** ), headers, tables, tabs, and forms.

--- a/skills/themes/domo-app-theme/references/themes/terminal-sage.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/terminal-sage.DESIGN.md
@@ -395,6 +395,13 @@ Mirror semantic names in `:root` for custom apps (`--surface` → `c2`, `--text-
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/themes/domo-app-theme/references/themes/terracotta-sand.DESIGN.md
+++ b/skills/themes/domo-app-theme/references/themes/terracotta-sand.DESIGN.md
@@ -268,6 +268,13 @@ const COLORS = {
 
 ---
 
+> **UI Import vs API format:** The JSON below is for the App Studio UI import dialog
+> (Theme Editor -> Import). For programmatic updates via `community-domo-cli app-studio update`:
+> - Colors: use `id` (e.g., `"c1"`) not `index`; value is `{"value": "#HEX", "type": "RGB_HEX"}` not a flat string; preserve the `tags` array
+> - Fonts: use `id` (e.g., `"f1"`) not `index`; `weight` must be numeric (300/400/600/700) not string; `size` must be numeric (no `"px"`); `style` must be `"Regular"` not `"normal"`
+> - Card styles: use `id` (e.g., `"ca1"`) not `index`; `dropShadow` valid values are `null`, `"FLOATING"`, `"STANDARD"`; `padding` is `{left:N, right:N, top:N, bottom:N}` not a single integer
+> - **Do not replace** the entire colors/fonts/cards array — iterate existing entries and update `value` fields to preserve tags/metadata the UI import format omits.
+
 ## 8. App Studio Theme JSON (Importable)
 
 ```json

--- a/skills/transformation/magic-etl-cli/SKILL.md
+++ b/skills/transformation/magic-etl-cli/SKILL.md
@@ -279,6 +279,10 @@ For an **existing** output dataset:
 
 Actions are the nodes in the DAG. Each action has a unique `id`, a `type`, and references its upstream dependencies via `dependsOn`.
 
+Valid types: `LoadFromVault`, `PublishToVault`, `MergeJoin`, `GroupBy`, `WindowAction`, `Filter`, `ExpressionEvaluator`, `SQL`
+
+NOT valid (will fail with `DP-0069`): `SaveToVault`, `SelectValues`, `RenameColumns`
+
 ### Common Action Fields
 
 Every action has these fields:
@@ -844,7 +848,7 @@ Removes duplicate rows based on specified key columns. This is the programmatic 
 
 **Tip:** Add a Unique tile after joins that might fan out rows (e.g., many-to-many joins).
 
-### SelectValues (Column Selection / Rename)
+### SelectValues (Legacy / Not Valid for New Flows)
 
 Selects specific columns and optionally renames them.
 
@@ -892,40 +896,37 @@ Writes the final data to a Domo dataset.
 ```json
 {
   "type": "PublishToVault",
-  "id": "PublishToVault-output",
-  "name": "SFDC | Account Summary",
-  "dependsOn": ["MergeJoin-final"],
-  "disabled": false,
-  "removeByDefault": false,
-  "notes": [],
-  "settings": {"preferredDatabaseEntityType": "TEMP_VIEW"},
-  "gui": {"x": 1248, "y": 320, "color": null, "colorSource": null, "sampleJson": null},
-  "previewRowLimit": null,
+  "id": "PublishToVault-my-output",
+  "name": "Output Dataset Name",
+  "dependsOn": ["last-action-id"],
+  "settings": {"preferredDatabaseEntityType": "DYNAMIC_TABLE"},
+  "inputs": ["last-action-id"],
   "dataSource": {
+    "guid": null,
     "type": "DataFlow",
-    "name": "SFDC | Account Summary",
-    "cloudId": "domo"
+    "name": "Output Dataset Name",
+    "description": "",
+    "cloudId": null
   },
   "versionChainType": "REPLACE",
-  "partitionIdColumns": [],
-  "upsertColumns": [],
-  "retainPartitionExpression": ""
+  "schemaSource": "DATAFLOW",
+  "partitioned": false,
+  "tables": [{}]
 }
 ```
 
 | Field | Description |
 |---|---|
-| `dependsOn` | Array with a single action ID — the final transform step |
+| `dependsOn` | Array with the final transform action ID |
+| `inputs` | Must include the same final transform action ID |
 | `dataSource.type` | `"DataFlow"` |
 | `dataSource.name` | Name for the output dataset |
-| `dataSource.guid` | UUID of existing output dataset — **omit entirely for new datasets** |
-| `dataSource.cloudId` | `"domo"` |
+| `dataSource.guid` | `null` for new outputs, existing UUID for existing output dataset |
+| `dataSource.cloudId` | `null` for standard dataflow-managed output |
 | `versionChainType` | `"REPLACE"` (full replace) or `"APPEND"` |
-| `partitionIdColumns` | `[]` — always empty unless using partitioning |
-| `upsertColumns` | `[]` — always empty unless doing upserts |
-| `retainPartitionExpression` | `""` — always empty string |
-
-**CRITICAL:** Do NOT include `inputs`, `schemaSource`, `partitioned`, or `tables` in PublishToVault. These fields cause `DP-DSCF` commit failures where the ETL processes all rows successfully but then fails to write to the output dataset. This was confirmed through extensive testing (April 2026).
+| `schemaSource` | `"DATAFLOW"` |
+| `partitioned` | `false` |
+| `tables` | `[{}]` |
 
 For new dataflows, omit `guid` entirely. Domo assigns a real output dataset UUID on the first successful run.
 
@@ -1156,32 +1157,37 @@ for e in errors:
 
 ## Common Pitfalls
 
-### 1. `DP-DSCF` Commit Failure — Wrong PublishToVault Structure
+### 1. `DP-DSCF`/`DP-0069` Failures — Wrong Action Type or PublishToVault Structure
 
-The error `"Failed to commit data to data source <UUID>"` (code `DP-DSCF`) is caused by incorrect `PublishToVault` fields. The ETL will process all rows successfully but then fail at the commit step.
+`DP-0069` means an illegal action type was used (for example `SaveToVault`, `SelectValues`, `RenameColumns`). `DP-DSCF` indicates output commit failure and is commonly tied to malformed `PublishToVault` payloads.
 
-**Root cause (confirmed April 2026):** Using `inputs`, `schemaSource`, `partitioned`, or `tables` in the `PublishToVault` action.
+**Root causes:** unsupported action type or incomplete/incorrect `PublishToVault` shape.
 
-**Fix:** Use this exact structure — `partitionIdColumns`, `upsertColumns`, `retainPartitionExpression` — and omit `inputs`, `schemaSource`, `partitioned`, `tables`:
+**Fix:** use supported action types and use this `PublishToVault` shape:
 
 ```json
 {
   "type": "PublishToVault",
-  "dataSource": {"type": "DataFlow", "name": "Output Name", "cloudId": "domo"},
+  "id": "PublishToVault-my-output",
+  "name": "Output Dataset Name",
+  "dependsOn": ["last-action-id"],
+  "settings": {"preferredDatabaseEntityType": "DYNAMIC_TABLE"},
+  "inputs": ["last-action-id"],
+  "dataSource": {"guid": null, "type": "DataFlow", "name": "Output Dataset Name", "description": "", "cloudId": null},
   "versionChainType": "REPLACE",
-  "partitionIdColumns": [],
-  "upsertColumns": [],
-  "retainPartitionExpression": ""
+  "schemaSource": "DATAFLOW",
+  "partitioned": false,
+  "tables": [{}]
 }
 ```
 
-### 2. SelectValues — Domo Strips `select` on Save (Zero Columns Downstream)
+### 2. SelectValues — Legacy Failure Mode (Do Not Use)
 
-On save, Domo can **strip the `select` array** from `SelectValues` actions. The tile then passes **no columns** to downstream nodes, breaking the DAG in ways that are easy to miss until execution.
+`SelectValues` is a recurring source of failures and should be treated as unsupported for new automation in this skill.
 
-**Recommendation:** **Omit `SelectValues` entirely** when you only need to narrow columns before output. Set **`PublishToVault.dependsOn`** directly to the final **`MergeJoin`** (or whatever the last real transform is). Let the join output define the schema for the vault.
+**Recommendation:** omit `SelectValues` entirely. Set `PublishToVault.dependsOn` directly to the final transform node (usually `MergeJoin`) and let that output schema flow through.
 
-If you must use `SelectValues`, prefer the `fields` format and only list columns to **keep** (no `"remove": true`, no extra `type` / `dateFormat` / `settings` — those cause `DP-0003 Action is improperly configured`):
+Legacy reference (for diagnosis only): older payloads used `fields` with keep-only columns (no `"remove": true`, no extra `type` / `dateFormat` / `settings`).
 
 ```json
 "fields": [
@@ -1320,7 +1326,7 @@ All action types discovered across existing dataflows in the instance:
 | `MergeJoin` | Join two upstream actions on keys | Yes |
 | `GroupBy` | Aggregate with SUM, AVERAGE, MIN, COUNT_ALL, etc. | Yes |
 | `WindowAction` | Rank & Window — ROW_NUMBER, RANK, LAG, LEAD | Yes |
-| `SelectValues` | Select and rename columns | Risky — Domo may strip `select` on save (see Gotcha #2); prefer wiring `PublishToVault` to the last join |
+| `SelectValues` | Legacy select/rename node | Not valid for new flow authoring in this skill; use supported transform chain + `PublishToVault` |
 | `Filter` | Filter rows based on conditions (NE, EQ, NN, etc.) | Yes |
 | `ExpressionEvaluator` | Add calculated columns / formulas (concat, year, MONTHNAME, DATE) | Yes |
 | `Unique` | Deduplicate rows by key columns | Documented (from patterns guide) |


### PR DESCRIPTION
This aligns cross-skill references to flat installed paths, clarifies CLI/datagen auth boundaries, adds theme UI-vs-API warnings, and completes remaining demo/ETL guidance updates from SKILL_UPDATE_PLAN.

Made-with: Cursor